### PR TITLE
chore(deps): update dependencies in workspace and projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -888,8 +897,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -981,7 +1002,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 name = "dwall"
 version = "0.1.0"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "regex",
  "serde",
  "serde_json",
@@ -992,14 +1013,14 @@ dependencies = [
  "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
- "windows 0.59.0",
+ "windows",
 ]
 
 [[package]]
 name = "dwall-settings"
 version = "0.1.0"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
  "dwall",
  "futures-util",
  "open",
@@ -1015,7 +1036,8 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tracing",
- "windows 0.59.0",
+ "tracing-subscriber",
+ "windows",
  "zip-extract",
 ]
 
@@ -3452,6 +3474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "serde_valid"
-version = "0.25.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16699789709912801b291052d20ba1719a9cc7c121cf89019c2df9610c1ea114"
+checksum = "3b615bed66931a7a9809b273937adc8a402d038b1e509d027fcaf62f084d33d1"
 dependencies = [
  "indexmap 2.7.1",
  "itertools",
@@ -3892,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "serde_valid_derive"
-version = "0.25.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd65bc62e51230170365b587d0d82a20e51bdab31d03e24c71abb234dc5fe5f"
+checksum = "5fa1a5a21ea5aab06d2e6a6b59837d450fb2be9695be97735a711edfbe79ea07"
 dependencies = [
  "itertools",
  "paste",
@@ -3907,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "serde_valid_literal"
-version = "0.25.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20d693075cf1bddff6c616a5e51768b159ab9f2bf0a32108fe2a8600f0746e3"
+checksum = "dd07331596ea967dccf9a35bde71ecd757490e09827b938a5c6226c648e3a25e"
 dependencies = [
  "paste",
  "regex",
@@ -4289,7 +4322,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
  "windows-version",
  "x11-dl",
@@ -4331,7 +4364,7 @@ checksum = "78f6efc261c7905839b4914889a5b25df07f0ff89c63fb4afd6ff8c96af15e4d"
 dependencies = [
  "anyhow",
  "bytes",
- "dirs",
+ "dirs 5.0.1",
  "dunce",
  "embed_plist",
  "futures-util",
@@ -4371,7 +4404,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -4382,7 +4415,7 @@ checksum = "8e950124f6779c6cf98e3260c7a6c8488a74aa6350dd54c6950fdaa349bca2df"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 5.0.1",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4527,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2d39224390c41ba544f02b4f1721f42256320b3fb8c371e9425cbddeb4a68c"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 5.0.1",
  "flate2",
  "futures-util",
  "http",
@@ -4566,7 +4599,7 @@ dependencies = [
  "tauri-utils",
  "thiserror 2.0.11",
  "url",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -4591,7 +4624,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.58.0",
+ "windows",
  "wry",
 ]
 
@@ -5011,7 +5044,7 @@ checksum = "d48a05076dd272615d03033bf04f480199f7d1b66a8ac64d75c625fc4a70c06b"
 dependencies = [
  "core-graphics",
  "crossbeam-channel",
- "dirs",
+ "dirs 5.0.1",
  "libappindicator",
  "muda",
  "objc2",
@@ -5464,10 +5497,10 @@ checksum = "823e7ebcfaea51e78f72c87fc3b65a1e602c321f407a0b36dbb327d7bb7cd921"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
+ "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
@@ -5488,7 +5521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a82bce72db6e5ee83c68b5de1e2cd6ea195b9fbff91cb37df5884cbe3222df4"
 dependencies = [
  "thiserror 1.0.69",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
 ]
 
@@ -5548,16 +5581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5572,24 +5595,11 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface 0.59.0",
- "windows-result 0.3.0",
- "windows-strings 0.3.0",
- "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -5597,17 +5607,6 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5626,24 +5625,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -5657,31 +5645,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
-dependencies = [
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
-dependencies = [
- "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -6048,7 +6018,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
  "windows-version",
  "x11-dl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,25 @@ repository = "https://github.com/dwall-rs/dwall"
 # license = "Apache-2.0 OR MIT"
 edition = "2021"
 
+[workspace.dependencies]
+dirs = "6"
+thiserror = { version = "2", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde_json = "1"
+tracing = { version = "0", default-features = false, features = [
+  "log",
+  "release_max_level_info",
+] }
+tracing-subscriber = { version = "0", default-features = false, features = [
+  "fmt",
+  'time',
+  "local-time",
+  'env-filter',
+  'json',
+] }
+tokio = { version = "1", default-features = false }
+windows = { version = "0.58", default-features = false }
+
 [profile.release]
 panic = "abort"
 codegen-units = 1

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -11,7 +11,31 @@ repository.workspace = true
 # license.workspace = true
 
 [dependencies]
-windows = { version = "0", default-features = false, features = [
+serde_valid = "1"
+time = { version = "0", default-features = false, features = [
+  'macros',
+  'serde',
+] }
+toml = { version = "0", default-features = false, features = [
+  "display",
+  "parse",
+] }
+tokio = { workspace = true, features = [
+  "sync",
+  "macros",
+  "time",
+  "fs",
+  "rt",
+  "rt-multi-thread",
+] }
+regex = { version = "1", default-features = false }
+dirs = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+windows = { workspace = true, default-features = false, features = [
   "Devices_Geolocation",
   "Win32_System_Registry",
   "System_UserProfile",
@@ -21,39 +45,6 @@ windows = { version = "0", default-features = false, features = [
   "Win32_UI_WindowsAndMessaging",
   "Win32_System_Com",
 ] }
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = "1"
-serde_valid = "0"
-tokio = { version = "1", default-features = false, features = [
-  "sync",
-  "macros",
-  "time",
-  "fs",
-  "rt",
-  "rt-multi-thread",
-] }
-time = { version = "0", default-features = false, features = [
-  'macros',
-  'serde',
-] }
-tracing = { version = "0", default-features = false, features = [
-  "log",
-  "release_max_level_info",
-] }
-tracing-subscriber = { version = "0", default-features = false, features = [
-  "fmt",
-  'time',
-  "local-time",
-  'env-filter',
-  'json',
-] }
-thiserror = { version = "2", default-features = false }
-toml = { version = "0", default-features = false, features = [
-  "display",
-  "parse",
-] }
-dirs = { version = "5", default-features = false }
-regex = { version = "1", default-features = false }
 
 [features]
 default = []

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,18 +22,18 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["protocol-asset"] }
 dwall = { version = "0", path = "../daemon" }
 
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", default-features = false, features = [
-  "macros",
-  "process",
-] }
-tracing = { version = "0", default-features = false, features = [
-  "log",
-  "release_max_level_info",
-] }
-thiserror = "2"
-windows = { version = "0", default-features = false, features = [
+reqwest = "0"
+futures-util = "0"
+zip-extract = "0"
+open = "5"
+tokio = { workspace = true, features = ["macros", "process"] }
+dirs = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+windows = { workspace = true, features = [
   "Win32_System_Registry",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_ProcessStatus",
@@ -41,12 +41,8 @@ windows = { version = "0", default-features = false, features = [
   "Wdk_System_SystemServices",
   "Win32_System_SystemInformation",
   "Win32_Globalization",
+  "Win32_System_Threading",
 ] }
-reqwest = "0"
-futures-util = "0"
-zip-extract = "0"
-open = "5"
-dirs = "5"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tauri-plugin-single-instance = "2"


### PR DESCRIPTION
- Added [workspace.dependencies] section to root Cargo.toml with common dependencies.
- Updated dependency versions and features in the workspace.
- Harmonized dependency definitions across daemon and src-tauri projects by referencing the workspace.
- Removed redundant dependency declarations within individual project Cargo.toml files.