### PR TITLE
chore(nightly.yml): Simplify and update nightly release workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,40 +53,24 @@ jobs:
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
 
       - name: get old nightly release id
-        id: get-release
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              const { data } = await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner,
-                repo: "dwall-assets",
-                tag: "nightly",
-                })
-                return data.id
-            } catch (error) {
-              if (error.status === 404) {
-                core.info(`Release nightly not found`)
-              } else {
-                throw error
-              }
-            }
+        run: |
+          release_id=$(curl -s 'https://api.github.com/repos/dwall-rs/dwall/releases/tags/nightly' | awk -F'[{},:]+' '/^  "id"/ {print $2}' | xargs)
+          echo "RELEASE_ID=$release_id"  >> $GITHUB_ENV
 
       - name: delete old nightly release
-        if: steps.get-release.outputs.result != ''
-        run: gh release delete nightly --cleanup-tag -R thep0y/dwall-assets
+        if: env.RELEASE_ID != ''
+        run: gh release delete nightly --cleanup-tag
         env:
-          GH_TOKEN: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: create release
         id: create-release
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
           script: |
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
-              repo: "dwall-assets",
+              repo: context.repo.repo,
               tag_name: "nightly",
               name: "Nightly build",
               draft: true,
@@ -149,9 +133,8 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo: "dwall-assets"
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.args }}
 
@@ -162,42 +145,18 @@ jobs:
     needs: [create-release, build-tauri]
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get meaningful commit message
-        id: get-commit-message
-        run: |
-          echo "DEBUG: Current branch: $(git branch --show-current)"
-          echo "DEBUG: Last commit: $(git log --pretty=format:'%s' -n 1 || echo 'No commits found')"
-
-          LAST_COMMIT_MESSAGE=$(git log --pretty=format:"%s" -n 1 --skip=0 | grep -v "^Merge pull request" || true)
-          if [ -z "$LAST_COMMIT_MESSAGE" ]; then
-            LAST_COMMIT_MESSAGE=$(git log --pretty=format:"%s" -n 1 --skip=1 || echo 'No meaningful commit found')
-          fi
-
-          if [ -z "$LAST_COMMIT_MESSAGE" ]; then
-            echo "Error: No meaningful commit message found"
-            exit 1
-          fi
-
-          echo "LAST_COMMIT_MESSAGE=$LAST_COMMIT_MESSAGE" >> $GITHUB_ENV
-
       - name: publish release
         id: publish-release
         uses: actions/github-script@v7
         env:
           release_id: ${{ needs.create-release.outputs.release_id }}
           PACKAGE_VERSION: ${{ needs.create-release.outputs.package_version }}
-          LAST_COMMIT_MESSAGE: ${{ env.LAST_COMMIT_MESSAGE }}
+          LAST_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         with:
-          github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
           script: |
             github.rest.repos.updateRelease({
               owner: context.repo.owner,
-              repo: "dwall-assets",
+              repo: context.repo.repo,
               release_id: parseInt(process.env.release_id),
               body: `> [!WARNING]\n> 每夜版可能无法自动升级。/The nightly version may not auto-update.\n\n## Last Commit\n\n${process.env.LAST_COMMIT_MESSAGE}`,
               draft: false


### PR DESCRIPTION
- Replace custom script with curl command for fetching old nightly release ID.
- Standardize on using GITHUB_TOKEN for authentication in GitHub API calls.
- Remove redundant checkout and commit message extraction steps.
- Directly use the latest commit message from GitHub event payload.
- Adjust repository reference to dynamic context.repo.repo.

This change streamlines the nightly build process, reducing complexity and improving maintainability.