### PR TITLE
chore(publish): update workflow and config for repository context

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,8 @@ jobs:
           configuration: ".github/changelog-configuration.json"
           toTag: "refs/heads/main"
           failOnError: true
-          token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: create release
         id: create-release
@@ -63,11 +64,10 @@ jobs:
         env:
           changelog: ${{ steps.github_release_changelog.outputs.changelog }}
         with:
-          github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
           script: |
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
-              repo: "dwall-assets",
+              repo: context.repo.repo,
               tag_name: `v${process.env.PACKAGE_VERSION}`,
               name: `v${process.env.PACKAGE_VERSION}`,
               body: process.env.changelog,
@@ -130,9 +130,8 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          repo: "dwall-assets"
           releaseId: ${{ needs.create-release.outputs.release_id }}
           releaseBody: ${{ needs.create-release.outputs.changelog }}
           updaterJsonPreferNsis: true
@@ -152,27 +151,12 @@ jobs:
           release_id: ${{ needs.create-release.outputs.release_id }}
           PACKAGE_VERSION: ${{ needs.create-release.outputs.package_version }}
         with:
-          github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
           script: |
             github.rest.repos.updateRelease({
               owner: context.repo.owner,
-              repo: "dwall-assets",
+              repo: context.repo.repo,
               release_id: process.env.release_id,
               draft: false,
-            })
-
-      - name: create new tag
-        uses: actions/github-script@v7
-        env:
-          PACKAGE_VERSION: ${{ needs.create-release.outputs.package_version }}
-        with:
-          github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `refs/tags/v${process.env.PACKAGE_VERSION}`,
-              sha: context.sha
             })
 
   upload_mirror_json:
@@ -190,12 +174,11 @@ jobs:
         id: get-latest
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
           script: |
-            const { owner } = context.repo;
+            const { owner, repo } = context.repo;
             const assets = await github.rest.repos.listReleaseAssets({
               owner: owner,
-              repo: "dwall-assets",
+              repo: repo,
               release_id: process.env.release_id,
               per_page: 50,
             });
@@ -207,7 +190,7 @@ jobs:
               "GET /repos/{owner}/{repo}/releases/assets/{asset_id}",
               {
                 owner: owner,
-                repo: "dwall-assets",
+                repo: repo,
                 asset_id: asset.id,
                 headers: {
                   accept: "application/octet-stream",
@@ -244,24 +227,11 @@ jobs:
 
       - name: get old nightly release id
         run: |
-          release_id=$(curl -s 'https://api.github.com/repos/thep0y/dwall-assets/releases/tags/nightly' | awk -F'[{},:]+' '/^  "id"/ {print $2}' | xargs)
+          release_id=$(curl -s 'https://api.github.com/repos/dwall-rs/dwall/releases/tags/nightly' | awk -F'[{},:]+' '/^  "id"/ {print $2}' | xargs)
           echo "RELEASE_ID=$release_id"  >> $GITHUB_ENV
 
-      # - name: delete old nightly release
-      #   uses: actions/github-script@v7
-      #   env:
-      #     PACKAGE_VERSION: ${{ needs.create-release.outputs.package_version }}
-      #   with:
-      #     github-token: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
-      #     script: |
-      #       github.rest.repos.deleteRelease({
-      #         owner: context.repo.owner,
-      #         repo: "dwall-assets",
-      #         release_id: process.env.RELEASE_ID,
-      #       })
-
-      - name: delete old nightly tag
+      - name: delete old nightly release
         if: env.RELEASE_ID != ''
-        run: gh release delete nightly --cleanup-tag -R thep0y/dwall-assets
+        run: gh release delete nightly --cleanup-tag
         env:
-          GH_TOKEN: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
       "endpoints": [
         "https://app.thepoy.cc/dwall/latest-mirror-1.json",
         "https://app.thepoy.cc/dwall/latest-mirror-2.json",
-        "https://github.com/thep0y/dwall/releases/latest/download/latest.json"
+        "https://github.com/dwall-rs/dwall/releases/latest/download/latest.json"
       ]
     }
   }


### PR DESCRIPTION
- Replace hardcoded `DWALL_ASSETS_GITHUB_TOKEN` with `GITHUB_TOKEN` in publish workflow.
- Update repo references to use dynamic `context.repo.repo`.
- Remove the job step that creates a new tag as it's no longer needed.
- Modify nightly release deletion command to reference the correct repository.
- Update `tauri.conf.json` endpoints URL to point to the new repository location.

This change ensures the workflow is more generic and adaptable to different repositories, while also cleaning up unnecessary steps.