### PR TITLE
style: Add custom scrollbar styles with dark mode support

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,28 @@
+:root {
+  --color-scrollbar: rgba(0, 0, 0, 0.1);
+  --color-scrollbar-hover: rgba(0, 0, 0, 0.4);
+}
+
 * {
   user-select: none;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  background: var(--color-scrollbar);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-scrollbar-hover);
+}
+
+::-webkit-scrollbar-track {
+  background-color: #fff0;
 }
 
 body {
@@ -16,6 +39,9 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --color-scrollbar: rgba(255, 255, 255, 0.1);
+    --color-scrollbar-hover: rgba(255, 255, 255, 0.4);
+
     --alley-color-text: #fff;
     --alley-color-text-description: rgba(255, 255, 255, 0.45);
     --alley-color-text-heading: rgba(255, 255, 255, 0.85);


### PR DESCRIPTION
- Introduced CSS variables for scrollbar colors (`--color-scrollbar` and `--color-scrollbar-hover`).
- Added custom scrollbar styles using `::-webkit-scrollbar`, `::-webkit-scrollbar-thumb`, and `::-webkit-scrollbar-track`.
- Updated dark mode styles to include scrollbar color adjustments for better visibility.
- Improved overall scrollbar aesthetics and user experience.