### PR TITLE
refactor: move inline styles to SCSS for better maintainability

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,3 +1,10 @@
+.app {
+  height: 100vh;
+  flex: 1;
+  padding: 0 0 10px 0;
+  justify-content: stretch;
+}
+
 .sidebar {
   height: 560px;
   display: flex;
@@ -7,7 +14,7 @@
 .thumbnails-container {
   flex: 7;
   overflow-y: auto;
-  padding: 10px;
+  padding: 10px 10px 10px 20px;
 }
 
 .sidebar-buttons {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,11 +89,7 @@ const App = () => {
         translations,
       }}
     >
-      <LazyFlex
-        style={{ height: "100vh", flex: 1, padding: "10px 0" }}
-        justify="round"
-        align="center"
-      >
+      <LazyFlex class="app" align="center">
         <LazyFlex
           direction="vertical"
           align="center"


### PR DESCRIPTION
The inline styles in App.tsx were moved to App.scss to improve code readability and maintainability. This change centralizes styling logic and reduces redundancy.