### PR TITLE
feat(i18n): add "Select Monitor" translation key and usage

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -13,6 +13,7 @@ pub(super) const LABEL_AUTOMATICALLY_SWITCH_TO_DARK_MODE: &str =
 pub(super) const LABEL_CHECK_INTERVAL: &str = "label-check-interval";
 pub(super) const LABEL_GITHUB_MIRROR_TEMPLATE: &str = "label-github-mirror-template";
 pub(super) const LABEL_LAUNCH_AT_STARTUP: &str = "label-launch-at-startup";
+pub(super) const LABEL_SELECT_MONITOR: &str = "label-select-monitor";
 pub(super) const LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY: &str =
     "label-set-lock-screen-wallpaper-simultaneously";
 pub(super) const LABEL_SOURCE_CODE: &str = "label-source-code";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -43,6 +43,10 @@ impl TranslationMap for EnglishUSTranslations {
             TranslationValue::Text("Launch at Startup"),
         );
         translations.insert(
+            LABEL_SELECT_MONITOR,
+            TranslationValue::Text("Select Monitor"),
+        );
+        translations.insert(
             LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
             TranslationValue::Text("Set Lock Screen Wallpaper Simultaneously"),
         );

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -33,6 +33,7 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             TranslationValue::Text("Github 镜像模板"),
         );
         translations.insert(LABEL_LAUNCH_AT_STARTUP, TranslationValue::Text("开机自启"));
+        translations.insert(LABEL_SELECT_MONITOR, TranslationValue::Text("选择显示器"));
         translations.insert(
             LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
             TranslationValue::Text("同时设置锁屏壁纸"),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,8 +28,10 @@ import {
 import { themes } from "./themes";
 
 import "./App.scss";
+import { useTranslations } from "./components/TranslationsContext";
 
 const App = () => {
+  const { translate } = useTranslations();
   const themeManager = useThemeSelector(themes);
 
   // 解构主题管理器中的各个部分
@@ -145,10 +147,10 @@ const App = () => {
           <LazyFlex direction="vertical" gap={16} align="center">
             <Select
               options={monitors()}
-              placeholder="选择显示器"
+              placeholder={translate("label-select-monitor")}
               onChange={handleMonitorChange}
               value={monitorID()}
-              label="选择显示器"
+              label={translate("label-select-monitor")}
             />
 
             <ThemeShowcase />

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -9,6 +9,7 @@ type TranslationKey =
   | "label-check-interval"
   | "label-github-mirror-template"
   | "label-launch-at-startup"
+  | "label-select-monitor"
   | "label-set-lock-screen-wallpaper-simultaneously"
   | "label-source-code"
   | "label-themes-directory"


### PR DESCRIPTION
Add the "label-select-monitor" translation key to support i18n for the monitor selection dropdown in the UI. This ensures consistent localization across the application.