### PR TITLE
refactor: translate debug logs and comments to English

### DIFF
--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -2,40 +2,73 @@ use windows::Win32::Foundation::WIN32_ERROR;
 
 use crate::color_mode::ColorModeRegistryError;
 
+/// Application result type, used for unified error handling
 pub type DwallResult<T> = std::result::Result<T, DwallError>;
 
+/// Application global error type
+///
+/// Contains all possible error types that may occur during application execution
 #[derive(Debug, thiserror::Error)]
 pub enum DwallError {
-    #[error(transparent)]
+    /// Input/Output error
+    #[error("IO operation failed: {0}")]
     Io(#[from] std::io::Error),
-    #[error("{0}")]
+
+    /// Windows API error
+    #[error("Windows system call failed: {0}")]
     Windows(#[from] windows::core::Error),
-    #[error(transparent)]
+
+    /// Theme-related error
+    #[error("Theme processing error: {0}")]
     Theme(#[from] crate::theme::ThemeError),
-    #[error(transparent)]
+
+    /// JSON serialization/deserialization error
+    #[error("JSON processing failed: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error(transparent)]
+
+    /// Configuration-related error
+    #[error("Configuration error: {0}")]
     Config(#[from] crate::config::ConfigError),
-    #[error(transparent)]
+
+    /// Color mode related error
+    #[error("Color mode setting failed: {0}")]
     ColorMode(#[from] ColorModeRegistryError),
-    #[error(transparent)]
+
+    /// Null character error
+    #[error("String contains null character: {0}")]
     NulError(#[from] std::ffi::NulError),
-    #[error(transparent)]
+
+    /// Time offset error
+    #[error("Unable to determine time offset: {0}")]
     TimeIndeterminateOffset(#[from] time::error::IndeterminateOffset),
-    #[error(transparent)]
+
+    /// Monitor related error
+    #[error("Monitor operation failed: {0}")]
     Monitor(#[from] crate::monitor::error::MonitorError),
 }
 
+/// Registry operation related errors
+///
+/// Contains all possible errors that may occur during interaction with the Windows registry
 #[derive(Debug, thiserror::Error)]
 pub enum RegistryError {
-    #[error("Failed open registry: {0:?}")]
+    /// Failed to open registry key
+    #[error("Failed to open registry key: {0:?}")]
     Open(WIN32_ERROR),
-    #[error("Failed query registry: {0:?}")]
+
+    /// Failed to query registry value
+    #[error("Failed to query registry value: {0:?}")]
     Query(WIN32_ERROR),
-    #[error("Failed set registry: {0:?}")]
+
+    /// Failed to set registry value
+    #[error("Failed to set registry value: {0:?}")]
     Set(WIN32_ERROR),
-    #[error("Failed close registry: {0:?}")]
+
+    /// Failed to close registry handle
+    #[error("Failed to close registry handle: {0:?}")]
     Close(WIN32_ERROR),
-    #[error("Failed delete registry: {0:?}")]
+
+    /// Failed to delete registry key
+    #[error("Failed to delete registry key: {0:?}")]
     Delete(WIN32_ERROR),
 }

--- a/daemon/src/monitor/device_interface.rs
+++ b/daemon/src/monitor/device_interface.rs
@@ -16,7 +16,10 @@ pub fn query_device_friendly_name(
     device_path: &str,
     device_guid: &windows::core::GUID,
 ) -> DwallResult<String> {
-    debug!("查询设备友好名称，设备路径: {}", device_path);
+    debug!(
+        "Querying device friendly name, device path: {}",
+        device_path
+    );
 
     unsafe {
         let mut device_info_set = get_device_info_set(device_guid)?;

--- a/daemon/src/monitor/display_config.rs
+++ b/daemon/src/monitor/display_config.rs
@@ -35,10 +35,7 @@ pub fn query_target_name(
     adapter_id: u32,
     target_id: u32,
 ) -> DwallResult<DISPLAYCONFIG_TARGET_DEVICE_NAME> {
-    debug!(
-        "查询目标设备名称: adapter_id={}, target_id={}",
-        adapter_id, target_id
-    );
+    debug!(adapter_id, target_id, "Querying target device name");
 
     let mut target_name: DISPLAYCONFIG_TARGET_DEVICE_NAME = unsafe { mem::zeroed() };
     target_name.header = DISPLAYCONFIG_DEVICE_INFO_HEADER {

--- a/daemon/src/monitor/error.rs
+++ b/daemon/src/monitor/error.rs
@@ -1,19 +1,35 @@
 use windows::Win32::Foundation::WIN32_ERROR;
 
+/// Monitor operation related errors
+///
+/// Contains all possible errors that may occur during interaction with monitor devices
 #[derive(Debug, thiserror::Error)]
 pub enum MonitorError {
-    #[error("Failed to get monitor set")]
+    /// Unable to get monitor device collection
+    #[error("Unable to get monitor device collection")]
     GetDeviceInfoSet,
-    #[error("Failed to get monitor")]
+
+    /// Unable to get monitor device information
+    #[error("Unable to get monitor device information")]
     GetDeviceInfo,
-    #[error("Failed to get target name")]
+
+    /// Unable to get target device name
+    #[error("Unable to get target device name")]
     GetTargetName,
-    #[error("Failed to find matching device")]
+
+    /// Unable to find matching device
+    #[error("Unable to find matching device")]
     MatchDevice,
-    #[error("Failed to get friendly name")]
+
+    /// Unable to get device friendly name
+    #[error("Unable to get device friendly name")]
     GetFriendlyName,
-    #[error("Failed to get buffer sizes")]
+
+    /// Unable to get buffer sizes
+    #[error("Unable to get buffer sizes")]
     GetBufferSizes,
-    #[error("Failed to query display config: {0:?}")]
+
+    /// Failed to query display configuration
+    #[error("Failed to query display configuration: {0:?}")]
     QueryDisplayConfig(WIN32_ERROR),
 }

--- a/daemon/src/monitor/mod.rs
+++ b/daemon/src/monitor/mod.rs
@@ -46,7 +46,7 @@ impl MonitorManager {
         monitor_id: &str,
         wallpaper_path: &std::path::Path,
     ) -> DwallResult<()> {
-        // 验证壁纸路径是否存在
+        // Verify wallpaper path exists
         if !wallpaper_path.exists() {
             error!(
                 image_path = %wallpaper_path.display(),
@@ -57,10 +57,10 @@ impl MonitorManager {
             );
         }
 
-        // 获取所有显示器
+        // Get all monitors
         let monitors = query_monitor_info()?;
 
-        // 查找指定ID的显示器
+        // Find monitor with specified ID
         let monitor = monitors.get(monitor_id).ok_or_else(|| {
             error!(
                 monitor_id = monitor_id,
@@ -69,12 +69,12 @@ impl MonitorManager {
             std::io::Error::new(std::io::ErrorKind::NotFound, "Monitor not found")
         })?;
 
-        // 转换壁纸路径为HSTRING
+        // Convert wallpaper path to HSTRING
         let wallpaper_path = windows::core::HSTRING::from(wallpaper_path);
 
         let device_path = HSTRING::from(&monitor.device_path);
 
-        // 设置壁纸
+        // Set wallpaper
         unsafe {
             self.desktop_wallpaper
                 .SetWallpaper(&device_path, &wallpaper_path)
@@ -139,6 +139,6 @@ fn query_monitor_info() -> DwallResult<HashMap<String, MonitorInfo>> {
         }
     }
 
-    info!("共找到 {} 个显示器", monitor_info.len());
+    info!("Found {} monitors in total", monitor_info.len());
     Ok(monitor_info)
 }


### PR DESCRIPTION
Improve code readability and maintainability by translating debug logs and comments from Chinese to English. This ensures consistency across the codebase and makes it more accessible to a broader audience.