### PR TITLE
refactor(settings): change help prop type from string to JSXElement

### DIFF
--- a/src/components/Settings/item.tsx
+++ b/src/components/Settings/item.tsx
@@ -1,5 +1,5 @@
-import { BsQuestionCircle } from "solid-icons/bs";
 import { children, type JSXElement } from "solid-js";
+import { BsQuestionCircle } from "solid-icons/bs";
 import {
   LazyButton,
   LazyFlex,
@@ -11,7 +11,7 @@ import {
 interface BaseProps {
   label: string;
   children: JSXElement;
-  help?: string;
+  help?: JSXElement;
 }
 
 interface VerticalLayout {


### PR DESCRIPTION
The help prop in the BaseProps interface has been updated to accept JSXElement instead of string. This allows for more flexible and rich content to be passed as help text, such as formatted text or interactive elements.