### PR TITLE
feat(i18n): add help text for manually setting coordinates

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -5,6 +5,9 @@ pub(super) const BUTTON_OPEN_LOG_DIRECTORY: &str = "button-open-log-directory";
 pub(super) const BUTTON_SELECT_FOLDER: &str = "button-select-folder";
 pub(super) const BUTTON_STOP: &str = "button-stop";
 
+// ---------------- help ----------------
+pub(super) const HELP_MANUALLY_SET_COORDINATES: &str = "help-manually-set-coordinates";
+
 // ---------------- labels ----------------
 pub(super) const LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES: &str =
     "label-automatically-retrieve-coordinates";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -21,6 +21,12 @@ impl TranslationMap for EnglishUSTranslations {
         );
         translations.insert(BUTTON_STOP, TranslationValue::Text("Stop"));
 
+        // helps
+        translations.insert(
+            HELP_MANUALLY_SET_COORDINATES,
+            TranslationValue::Text("When manually setting coordinates, you must use the WGS84 coordinate system (the international standard, users in China should take note). Otherwise, coordinate offset issues may occur, leading to inaccurate wallpaper alignment."), 
+        );
+
         // labels
         translations.insert(
             LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES,

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -18,6 +18,12 @@ impl TranslationMap for ChineseSimplifiedTranslations {
         translations.insert(BUTTON_SELECT_FOLDER, TranslationValue::Text("修改"));
         translations.insert(BUTTON_STOP, TranslationValue::Text("停止"));
 
+        // helps
+        translations.insert(
+            HELP_MANUALLY_SET_COORDINATES,
+            TranslationValue::Text("手动设置坐标时需要使用WGS84坐标系（国际通用坐标系，中国用户需要注意），否则会存在坐标偏移问题使得壁纸匹配不精确。"), 
+        );
+
         // labels
         translations.insert(
             LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES,

--- a/src/components/Settings/CoordinateSource.tsx
+++ b/src/components/Settings/CoordinateSource.tsx
@@ -181,6 +181,7 @@ const CoordinateSource = () => {
     <SettingsItem
       layout="horizontal"
       label={getTranslation("label-automatically-retrieve-coordinates")}
+      help={auto() ? undefined : translate("help-manually-set-coordinates")}
       extra={renderCoordinateInputs()}
     >
       <LazySpace gap={auto() ? 0 : 8}>

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -4,6 +4,7 @@ type TranslationKey =
   | "button-download"
   | "button-open-log-directory"
   | "button-select-folder"
+  | "help-manually-set-coordinates"
   | "label-automatically-retrieve-coordinates"
   | "label-automatically-switch-to-dark-mode"
   | "label-check-interval"


### PR DESCRIPTION
Add a new translation key "help-manually-set-coordinates" to provide guidance on using the WGS84 coordinate system when manually setting coordinates. This ensures users are aware of potential inaccuracies due to coordinate offset issues. The help text is displayed in the CoordinateSource component when automatic coordinate retrieval is disabled.