### PR TITLE
refactor(Select): remove unused warning state and prop

### DIFF
--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -10,7 +10,6 @@ const Select: Component<SelectProps> = (props) => {
   const [selectedValue, setSelectedValue] = createSignal<string | undefined>(
     props.value,
   );
-  const [warning, setWarning] = createSignal<string | undefined>();
 
   // 引用下拉菜单和选择器容器
   let dropdownRef: HTMLDivElement | undefined;
@@ -96,11 +95,7 @@ const Select: Component<SelectProps> = (props) => {
   };
 
   return (
-    <InputContainer
-      label={props.label}
-      required={props.required}
-      warning={warning()}
-    >
+    <InputContainer label={props.label} required={props.required}>
       <div
         ref={selectRef}
         class={selectWrapperClass()}


### PR DESCRIPTION
The warning state and its corresponding prop in the InputContainer were unused and unnecessary. This cleanup improves code maintainability by removing redundant code.