### PR TITLE
build(tauri): update installer icon and fix updater endpoint URL

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,8 @@
     "windows": {
       "nsis": {
         "languages": ["SimpChinese", "English"],
-        "displayLanguageSelector": true
+        "displayLanguageSelector": true,
+        "installerIcon": "icons/icon.ico"
       }
     }
   },
@@ -41,7 +42,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcxQTQ5NDZBNUIyMEVDRTUKUldUbDdDQmJhcFNrY2RYSkpGNUt0U3cvdEozMXJoN2pXeEFBcUQ4YmZMTi9MS2E2YjNQT1pSbTgK",
       "endpoints": [
-        "https://gh-proxy.com/dwall-rs/dwall/releases/latest/download/latest.json",
+        "https://gh-proxy.com/https://github.com/dwall-rs/dwall/releases/latest/download/latest.json",
         "https://app.thepoy.cc/dwall/latest-mirror-1.json",
         "https://app.thepoy.cc/dwall/latest-mirror-2.json",
         "https://github.com/dwall-rs/dwall/releases/latest/download/latest.json"


### PR DESCRIPTION
Add installer icon for the NSIS installer and correct the updater endpoint URL to ensure proper functionality.