### PR TITLE
build(tauri): add installer hooks for Windows NSIS

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,8 @@
       "nsis": {
         "languages": ["SimpChinese", "English"],
         "displayLanguageSelector": true,
-        "installerIcon": "icons/icon.ico"
+        "installerIcon": "icons/icon.ico",
+        "installerHooks": "./windows/hooks.nsi"
       }
     }
   },

--- a/src-tauri/windows/hooks.nsi
+++ b/src-tauri/windows/hooks.nsi
@@ -1,0 +1,42 @@
+!include "StrFunc.nsh"
+${StrStr}
+${UnStrStr}
+
+!macro NSIS_HOOK_PREINSTALL
+  nsis_tauri_utils::FindProcess "dwall.exe"
+  Pop $R0
+  ${If} $R0 = 0
+    nsExec::ExecToStack `wmic process where "name='dwall.exe'" get ExecutablePath`
+    Pop $R1
+    Pop $R2
+    ${StrStr} $R3 "$R2" "$INSTDIR"
+    ${If} $R3 != ""
+      nsis_tauri_utils::KillProcess "dwall.exe"
+      Pop $R0
+      Sleep 1000
+    ${EndIf}
+  ${EndIf}
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  nsis_tauri_utils::FindProcess "dwall.exe"
+  Pop $R0
+  ${If} $R0 = 0
+    nsExec::ExecToStack `wmic process where "name='dwall.exe'" get ExecutablePath`
+    Pop $R1
+    Pop $R2
+    ${UnStrStr} $R3 "$R2" "$INSTDIR"
+    ${If} $R3 != ""
+      nsis_tauri_utils::KillProcess "dwall.exe"
+      Pop $R0
+      Sleep 1000
+    ${EndIf}
+  ${EndIf}
+
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "Dwall"
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  RMDir /r "$APPDATA\dwall"
+  RMDir /r "$LOCALAPPDATA\dwall"
+!macroend


### PR DESCRIPTION
Added a new `hooks.nsi` file to handle pre-install, pre-uninstall, and post-uninstall hooks for the Windows NSIS installer. This ensures that the `dwall.exe` process is properly managed during installation and uninstallation, and related directories are cleaned up post-uninstallation.