### PR TITLE
build: remove outdated thumbnail directories in preinstall hook

### DIFF
--- a/src-tauri/windows/hooks.nsi
+++ b/src-tauri/windows/hooks.nsi
@@ -3,6 +3,12 @@ ${StrStr}
 ${UnStrStr}
 
 !macro NSIS_HOOK_PREINSTALL
+  # NOTE: Clear incomplete thumbnails saved by old versions
+  # ---- start: This hook will be removed in the future ----
+  RMDir /r "$LOCALAPPDATA\dwall"
+  RMDir /r "$LOCALAPPDATA\com.thep0y.dwall"
+  # ---- end ----
+
   nsis_tauri_utils::FindProcess "dwall.exe"
   Pop $R0
   ${If} $R0 = 0


### PR DESCRIPTION
Clean up incomplete thumbnails saved by old versions to ensure a clean installation environment. This hook is temporary and will be removed in the future.