### PR TITLE
feat(download): add cancel button for theme download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwall"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "dirs",
  "regex",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "dwall-settings"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "dirs",
  "dwall",

--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -1,5 +1,6 @@
 // ---------------- buttons ----------------
 pub(super) const BUTTON_APPLY: &str = "button-apply";
+pub(super) const BUTTON_CANCEL: &str = "button-cancel";
 pub(super) const BUTTON_DOWNLOAD: &str = "button-download";
 pub(super) const BUTTON_OPEN_LOG_DIRECTORY: &str = "button-open-log-directory";
 pub(super) const BUTTON_SELECT_FOLDER: &str = "button-select-folder";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -10,6 +10,7 @@ impl TranslationMap for EnglishUSTranslations {
 
         // buttons
         translations.insert(BUTTON_APPLY, TranslationValue::Text("Apply"));
+        translations.insert(BUTTON_CANCEL, TranslationValue::Text("Cancel"));
         translations.insert(BUTTON_DOWNLOAD, TranslationValue::Text("Download"));
         translations.insert(
             BUTTON_OPEN_LOG_DIRECTORY,

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -10,6 +10,7 @@ impl TranslationMap for ChineseSimplifiedTranslations {
 
         // buttons
         translations.insert(BUTTON_APPLY, TranslationValue::Text("应用"));
+        translations.insert(BUTTON_CANCEL, TranslationValue::Text("取消"));
         translations.insert(BUTTON_DOWNLOAD, TranslationValue::Text("下载"));
         translations.insert(
             BUTTON_OPEN_LOG_DIRECTORY,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::sync::OnceCell;
 
 use crate::auto_start::{check_auto_start, disable_auto_start, enable_auto_start};
 use crate::cache::get_or_save_cached_thumbnails;
-use crate::download::download_theme_and_extract;
+use crate::download::{cancel_theme_download, download_theme_and_extract};
 use crate::error::DwallSettingsResult;
 use crate::fs::move_themes_directory;
 use crate::i18n::get_translations;
@@ -223,6 +223,7 @@ pub fn run() -> DwallSettingsResult<()> {
             disable_auto_start,
             enable_auto_start,
             download_theme_and_extract,
+            cancel_theme_download,
             request_location_permission,
             open_dir,
             open_config_dir,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,6 +30,9 @@ export const downloadThemeAndExtract = async (
   themeId: string,
 ) => invoke<void>("download_theme_and_extract", { config, themeId });
 
+export const cancelThemeDownload = async (themeId: string) =>
+  invoke<void>("cancel_theme_download", { themeId });
+
 export const requestLocationPermission = async () =>
   invoke<void>("request_location_permission");
 

--- a/src/components/Download/index.scss
+++ b/src/components/Download/index.scss
@@ -1,4 +1,33 @@
+.download-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 .download-progress {
   position: absolute;
   bottom: 36px;
+}
+
+.cancel-download-btn {
+  padding: 8px 16px;
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background-color: #d32f2f;
+  }
+
+  &:active {
+    background-color: #b71c1c;
+  }
 }

--- a/src/components/Download/index.tsx
+++ b/src/components/Download/index.tsx
@@ -1,11 +1,11 @@
-import { createSignal, onMount } from "solid-js";
-import { LazyProgress } from "~/lazy";
-import "./index.scss";
+import { createSignal, onMount, Show } from "solid-js";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { downloadThemeAndExtract } from "~/commands";
-import { useAppContext } from "~/context";
 import { message } from "@tauri-apps/plugin-dialog";
+import { LazyButton, LazyProgress } from "~/lazy";
+import { downloadThemeAndExtract, cancelThemeDownload } from "~/commands";
+import { useAppContext } from "~/context";
 import { useTranslations } from "../TranslationsContext";
+import "./index.scss";
 
 interface DownloadProgress {
   theme_id: string;
@@ -19,10 +19,31 @@ const Download = () => {
   const { translate } = useTranslations();
   const { config, theme } = useAppContext()!;
   const [percent, setPercent] = createSignal<number>();
+  const [isCancelling, setIsCancelling] = createSignal(false);
 
   const onFinished = () => {
     theme.setDownloadThemeID();
     theme.handleThemeSelection(theme.menuItemIndex()!);
+  };
+
+  const handleCancelDownload = async () => {
+    if (isCancelling()) return;
+
+    setIsCancelling(true);
+    try {
+      await cancelThemeDownload(theme.downloadThemeID()!);
+      // 取消操作已发送，但实际取消会在后端处理
+    } catch (e) {
+      message(
+        translate("title-download-faild", {
+          error: String(e),
+        }),
+        {
+          title: translate("title-download-faild"),
+          kind: "error",
+        },
+      );
+    }
   };
 
   onMount(async () => {
@@ -37,15 +58,29 @@ const Download = () => {
     try {
       await downloadThemeAndExtract(config()!, theme.downloadThemeID()!);
     } catch (e) {
-      message(
-        translate("title-download-faild", {
-          error: String(e),
-        }),
-        {
-          title: translate("title-download-faild"),
-          kind: "error",
-        },
-      );
+      // 检查是否是取消下载导致的错误
+      if (String(e).includes("Download cancelled")) {
+        // message(
+        //   translate("download-cancelled", {
+        //     themeId: theme.downloadThemeID()!,
+        //   }) || `Download of ${theme.downloadThemeID()} was cancelled`,
+        //   {
+        //     title:
+        //       translate("download-cancelled-title") || "Download Cancelled",
+        //     kind: "info",
+        //   },
+        // );
+      } else {
+        message(
+          translate("title-download-faild", {
+            error: String(e),
+          }),
+          {
+            title: translate("title-download-faild"),
+            kind: "error",
+          },
+        );
+      }
     } finally {
       onFinished();
       setPercent();
@@ -53,7 +88,16 @@ const Download = () => {
     }
   });
 
-  return <LazyProgress class="download-progress" value={percent()} />;
+  return (
+    <div class="download-container">
+      <LazyProgress class="download-progress" value={percent()} />
+      <Show when={!isCancelling()}>
+        <LazyButton class="cancel-download-btn" onClick={handleCancelDownload}>
+          {translate("button-cancel") || "Cancel"}
+        </LazyButton>
+      </Show>
+    </div>
+  );
 };
 
 export default Download;

--- a/src/components/ThemeActions.tsx
+++ b/src/components/ThemeActions.tsx
@@ -37,12 +37,14 @@ export const ThemeActions = () => {
       <Show
         when={theme.themeExists()}
         fallback={
-          <LazyButton
-            onClick={() => theme.setDownloadThemeID(theme.currentTheme()!.id)}
-            disabled={!!theme.downloadThemeID()}
-          >
-            {translate("button-download")}
-          </LazyButton>
+          <Show when={!theme.downloadThemeID()}>
+            <LazyButton
+              onClick={() => theme.setDownloadThemeID(theme.currentTheme()!.id)}
+              disabled={!!theme.downloadThemeID()}
+            >
+              {translate("button-download")}
+            </LazyButton>
+          </Show>
         }
       >
         <Show

--- a/src/components/ThemeShowcase.tsx
+++ b/src/components/ThemeShowcase.tsx
@@ -11,7 +11,7 @@ const ThemeShowcase = () => {
   return (
     <LazyFlex
       direction="vertical"
-      gap={16}
+      gap={theme.downloadThemeID() ? 8 : 16}
       justify="center"
       align="center"
       style={{ position: "relative" }}

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -1,9 +1,10 @@
 type TranslationKey =
   | "button-apply"
-  | "button-stop"
+  | "button-cancel"
   | "button-download"
   | "button-open-log-directory"
   | "button-select-folder"
+  | "button-stop"
   | "help-manually-set-coordinates"
   | "label-automatically-retrieve-coordinates"
   | "label-automatically-switch-to-dark-mode"


### PR DESCRIPTION
Introduce a cancel button to allow users to stop an ongoing theme download. This includes backend support to handle cancellation, UI updates to display the button, and translations for the new "Cancel" button. The download process now checks for cancellation requests and cleans up resources if the download is cancelled.