### PR TITLE
refactor: extract app initialization logic into custom hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,16 +14,9 @@ import Select from "./components/Select";
 
 import { useColorMode } from "./hooks/useColorMode";
 import { useUpdateManager } from "./hooks/useUpdateManager";
-
-import { detectColorMode } from "./utils/color";
+import { useAppInitialization } from "./hooks/useAppInitialization";
 
 import { AppContext } from "./context";
-
-import {
-  showWindow,
-  getAppliedThemeID,
-  setTitlebarColorMode,
-} from "~/commands";
 
 import { themes } from "./themes";
 
@@ -77,25 +70,7 @@ const App = () => {
   useDark();
   useColorMode();
 
-  onMount(async () => {
-    await setTitlebarColorMode(detectColorMode());
-
-    if (!import.meta.env.PRODEV) await showWindow("main");
-
-    const mii = menuItemIndex();
-    if (mii !== undefined) handleThemeSelection(mii);
-
-    const applied_theme_id = await getAppliedThemeID();
-    if (applied_theme_id) {
-      const themeIndex = themes.findIndex((t) => t.id === applied_theme_id);
-      if (themeIndex !== -1) {
-        setMenuItemIndex(themeIndex);
-        handleThemeSelection(themeIndex);
-        setAppliedThemeID(applied_theme_id);
-        return;
-      }
-    }
-  });
+  useAppInitialization(menuItemIndex, handleThemeSelection);
 
   return (
     <AppContext.Provider

--- a/src/hooks/useAppInitialization.tsx
+++ b/src/hooks/useAppInitialization.tsx
@@ -1,0 +1,22 @@
+import { onMount } from "solid-js";
+import { setTitlebarColorMode, showWindow } from "~/commands";
+import { detectColorMode } from "~/utils/color";
+
+/**
+ * App initialization Hook, used to handle application startup logic
+ * @param menuItemIndex Current menu item index
+ * @param handleThemeSelection Function to handle theme selection
+ */
+export const useAppInitialization = (
+  menuItemIndex: Accessor<number | undefined>,
+  handleThemeSelection: (index: number) => void,
+) => {
+  onMount(async () => {
+    await setTitlebarColorMode(detectColorMode());
+
+    if (!import.meta.env.PRODEV) await showWindow("main");
+
+    const mii = menuItemIndex();
+    if (mii !== undefined) handleThemeSelection(mii);
+  });
+};


### PR DESCRIPTION
Move the app initialization logic from App.tsx to a reusable custom hook, useAppInitialization, to improve code maintainability and separation of concerns. This change reduces code duplication and makes the initialization logic more modular.