### PR TITLE
refactor(contexts): consolidate TranslationsContext into contexts directory

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,11 @@ import { useUpdateManager } from "./hooks/useUpdateManager";
 import { useAppInitialization } from "./hooks/useAppInitialization";
 
 import { AppContext } from "./context";
+import { useTranslations } from "~/contexts";
 
 import { themes } from "./themes";
 
 import "./App.scss";
-import { useTranslations } from "./components/TranslationsContext";
 
 const App = () => {
   const { translate } = useTranslations();

--- a/src/components/Download/index.tsx
+++ b/src/components/Download/index.tsx
@@ -4,7 +4,7 @@ import { message } from "@tauri-apps/plugin-dialog";
 import { LazyButton, LazyProgress } from "~/lazy";
 import { downloadThemeAndExtract, cancelThemeDownload } from "~/commands";
 import { useAppContext } from "~/context";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 import "./index.scss";
 
 interface DownloadProgress {

--- a/src/components/NumericInput/useNumericInput.ts
+++ b/src/components/NumericInput/useNumericInput.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import type { NumericInputProps } from "./types";
 
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 export const numberValidation = {
   isValidNumberInput: (value: string): boolean => {

--- a/src/components/Settings/AutoDetectColorMode.tsx
+++ b/src/components/Settings/AutoDetectColorMode.tsx
@@ -3,7 +3,7 @@ import SettingsItem from "./item";
 import { useAppContext } from "~/context";
 import { writeConfigFile } from "~/commands";
 import { message } from "@tauri-apps/plugin-dialog";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const AutoDetectColorMode = () => {
   const { config, refetchConfig } = useAppContext();

--- a/src/components/Settings/AutoStart.tsx
+++ b/src/components/Settings/AutoStart.tsx
@@ -4,7 +4,7 @@ import { createSignal, onMount } from "solid-js";
 import { checkAutoStart, disableAutoStart, enableAutoStart } from "~/commands";
 import { message } from "@tauri-apps/plugin-dialog";
 
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const AutoStart = () => {
   const { translate, translateErrorMessage } = useTranslations();

--- a/src/components/Settings/CoordinateSource.tsx
+++ b/src/components/Settings/CoordinateSource.tsx
@@ -6,7 +6,7 @@ import { writeConfigFile } from "~/commands";
 import { children, createMemo, createSignal, Show } from "solid-js";
 import NumericInput from "../NumericInput";
 import { message } from "@tauri-apps/plugin-dialog";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 interface CoordinateInputProps {
   min: number;

--- a/src/components/Settings/GithubMirror.tsx
+++ b/src/components/Settings/GithubMirror.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from "~/context";
 import { createSignal } from "solid-js";
 import { AiFillSave } from "solid-icons/ai";
 import { writeConfigFile } from "~/commands";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const GithubMirror = () => {
   const { config, refetchConfig } = useAppContext();

--- a/src/components/Settings/Interval.tsx
+++ b/src/components/Settings/Interval.tsx
@@ -5,7 +5,7 @@ import { createSignal } from "solid-js";
 import { writeConfigFile } from "~/commands";
 import NumericInput from "../NumericInput";
 import { AiFillSave } from "solid-icons/ai";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const Interval = () => {
   const { config, refetchConfig } = useAppContext();

--- a/src/components/Settings/LockScreenWallpaperSwitch.tsx
+++ b/src/components/Settings/LockScreenWallpaperSwitch.tsx
@@ -3,7 +3,7 @@ import SettingsItem from "./item";
 import { useContext } from "solid-js";
 import { AppContext } from "~/context";
 import { writeConfigFile } from "~/commands";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const LockScreenWallpaperSwitch = () => {
   const { config, refetchConfig } = useContext(AppContext)!;

--- a/src/components/Settings/ThemesDirectory.tsx
+++ b/src/components/Settings/ThemesDirectory.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from "~/context";
 import { createSignal } from "solid-js";
 import { moveThemesDirectory, openDir } from "~/commands";
 import { confirm, message, open } from "@tauri-apps/plugin-dialog";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const ThemesDirectory = () => {
   const { config, refetchConfig } = useAppContext();

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -25,7 +25,7 @@ import Interval from "./Interval";
 import GithubMirror from "./GithubMirror";
 import ThemesDirectory from "./ThemesDirectory";
 import LockScreenWallpaperSwitch from "./LockScreenWallpaperSwitch";
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 const Settings = () => {
   const {

--- a/src/components/SidebarButtons.tsx
+++ b/src/components/SidebarButtons.tsx
@@ -2,7 +2,7 @@ import { AiFillSetting } from "solid-icons/ai";
 import { TbArrowBigUpLinesFilled } from "solid-icons/tb";
 import { Show } from "solid-js";
 import { LazyButton, LazySpace, LazyTooltip } from "~/lazy";
-import { useTranslations } from "./TranslationsContext";
+import { useTranslations } from "~/contexts";
 import { useAppContext } from "~/context";
 
 const SidebarButtons = () => {

--- a/src/components/ThemeActions.tsx
+++ b/src/components/ThemeActions.tsx
@@ -1,6 +1,6 @@
 import { createSignal, Show } from "solid-js";
 import { LazyButton, LazySpace } from "~/lazy";
-import { useTranslations } from "./TranslationsContext";
+import { useTranslations } from "~/contexts";
 import { useAppContext } from "~/context";
 
 export interface ThemeActionsProps {

--- a/src/components/Update/UpdateDialog.tsx
+++ b/src/components/Update/UpdateDialog.tsx
@@ -4,7 +4,7 @@ import { createSignal, onMount } from "solid-js";
 import { LazyProgress } from "~/lazy";
 import Dialog from "../Dialog";
 
-import { useTranslations } from "../TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 interface UpdateDialogProps {
   update: Update;

--- a/src/contexts/TranslationsContext.tsx
+++ b/src/contexts/TranslationsContext.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, type JSX } from "solid-js";
-import { createResource } from "solid-js";
+import type { JSX } from "solid-js";
+import { createContext, useContext, createResource } from "solid-js";
 import { getTranslations } from "~/commands";
 import {
   translate as translateFn,

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export { useTranslations } from "./TranslationsContext";

--- a/src/hooks/theme/useThemeState.tsx
+++ b/src/hooks/theme/useThemeState.tsx
@@ -2,7 +2,7 @@ import { createSignal, createResource } from "solid-js";
 import { check } from "@tauri-apps/plugin-updater";
 import { message } from "@tauri-apps/plugin-dialog";
 import { readConfigFile } from "~/commands";
-import { useTranslations } from "~/components/TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 /**
  * Theme base state management Hook, used to manage theme-related base states

--- a/src/hooks/useLocationPermission.tsx
+++ b/src/hooks/useLocationPermission.tsx
@@ -2,7 +2,7 @@ import { requestLocationPermission } from "~/commands";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { exit } from "@tauri-apps/plugin-process";
 import { translate } from "~/utils/i18n";
-import { useTranslations } from "~/components/TranslationsContext";
+import { useTranslations } from "~/contexts";
 
 /**
  * Location permission management Hook, used to handle location permission requests and related operations

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { render } from "solid-js/web";
 import "fluent-solid/lib/index.css";
 import "./index.scss";
 import App from "./App";
-import { TranslationsProvider } from "./components/TranslationsContext";
+import { TranslationsProvider } from "./contexts/TranslationsContext";
 
 if (import.meta.env.MODE === "production") {
   document.addEventListener("contextmenu", (event) => event.preventDefault());


### PR DESCRIPTION
Move the TranslationsContext and related imports from the components directory to a new contexts directory to improve code organization and maintainability. This change centralizes context-related files and reduces redundancy in import paths.