### PR TITLE
refactor(contexts): consolidate context providers and hooks

### DIFF
--- a/src/components/Settings/AutoDetectColorMode.tsx
+++ b/src/components/Settings/AutoDetectColorMode.tsx
@@ -1,12 +1,14 @@
-import { LazySwitch } from "~/lazy";
-import SettingsItem from "./item";
-import { useAppContext } from "~/context";
-import { writeConfigFile } from "~/commands";
 import { message } from "@tauri-apps/plugin-dialog";
-import { useTranslations } from "~/contexts";
+
+import SettingsItem from "./item";
+import { LazySwitch } from "~/lazy";
+
+import { writeConfigFile } from "~/commands";
+
+import { useConfig, useTranslations } from "~/contexts";
 
 const AutoDetectColorMode = () => {
-  const { config, refetchConfig } = useAppContext();
+  const { data: config, refetch: refetchConfig } = useConfig();
   const { translate, translateErrorMessage } = useTranslations();
 
   const onSwitchAutoDetectColorMode = async () => {

--- a/src/components/Settings/AutoStart.tsx
+++ b/src/components/Settings/AutoStart.tsx
@@ -1,8 +1,11 @@
-import { LazySwitch } from "~/lazy";
-import SettingsItem from "./item";
 import { createSignal, onMount } from "solid-js";
-import { checkAutoStart, disableAutoStart, enableAutoStart } from "~/commands";
+
 import { message } from "@tauri-apps/plugin-dialog";
+
+import SettingsItem from "./item";
+import { LazySwitch } from "~/lazy";
+
+import { checkAutoStart, disableAutoStart, enableAutoStart } from "~/commands";
 
 import { useTranslations } from "~/contexts";
 

--- a/src/components/Settings/CoordinateSource.tsx
+++ b/src/components/Settings/CoordinateSource.tsx
@@ -1,12 +1,15 @@
+import { children, createMemo, createSignal, Show } from "solid-js";
+import { AiOutlineCheck } from "solid-icons/ai";
+
+import { message } from "@tauri-apps/plugin-dialog";
+
 import { LazyButton, LazySpace, LazySwitch } from "~/lazy";
 import SettingsItem from "./item";
-import { AiOutlineCheck } from "solid-icons/ai";
-import { useAppContext } from "~/context";
+import NumericInput from "~/components/NumericInput";
+
 import { writeConfigFile } from "~/commands";
-import { children, createMemo, createSignal, Show } from "solid-js";
-import NumericInput from "../NumericInput";
-import { message } from "@tauri-apps/plugin-dialog";
-import { useTranslations } from "~/contexts";
+
+import { useConfig, useTranslations } from "~/contexts";
 
 interface CoordinateInputProps {
   min: number;
@@ -46,7 +49,7 @@ const COORDINATE_LIMITS = {
 } as const;
 
 const CoordinateSource = () => {
-  const { config, refetchConfig } = useAppContext();
+  const { data: config, refetch: refetchConfig } = useConfig();
   const { translate } = useTranslations();
 
   const initialPosition: Omit<CoordinateSourceManual, "type"> =

--- a/src/components/Settings/GithubMirror.tsx
+++ b/src/components/Settings/GithubMirror.tsx
@@ -1,14 +1,16 @@
-import { LazyButton, LazyInput } from "~/lazy";
-import SettingsItem from "./item";
-import { useAppContext } from "~/context";
 import { createSignal } from "solid-js";
 import { AiFillSave } from "solid-icons/ai";
+
+import { LazyButton, LazyInput } from "~/lazy";
+import SettingsItem from "./item";
+
 import { writeConfigFile } from "~/commands";
-import { useTranslations } from "~/contexts";
+
+import { useConfig, useTranslations } from "~/contexts";
 
 const GithubMirror = () => {
-  const { config, refetchConfig } = useAppContext();
   const { translate } = useTranslations();
+  const { data: config, refetch: refetchConfig } = useConfig();
 
   const [value, setValue] = createSignal(config()?.github_mirror_template);
 

--- a/src/components/Settings/Interval.tsx
+++ b/src/components/Settings/Interval.tsx
@@ -1,14 +1,16 @@
+import { createSignal } from "solid-js";
+import { AiFillSave } from "solid-icons/ai";
+
 import { LazyButton, LazySpace } from "~/lazy";
 import SettingsItem from "./item";
-import { useAppContext } from "~/context";
-import { createSignal } from "solid-js";
+import NumericInput from "~/components/NumericInput";
+
 import { writeConfigFile } from "~/commands";
-import NumericInput from "../NumericInput";
-import { AiFillSave } from "solid-icons/ai";
-import { useTranslations } from "~/contexts";
+
+import { useConfig, useTranslations } from "~/contexts";
 
 const Interval = () => {
-  const { config, refetchConfig } = useAppContext();
+  const { data: config, refetch: refetchConfig } = useConfig();
   const { translate } = useTranslations();
 
   const [value, setValue] = createSignal(config()?.interval);

--- a/src/components/Settings/LockScreenWallpaperSwitch.tsx
+++ b/src/components/Settings/LockScreenWallpaperSwitch.tsx
@@ -1,12 +1,12 @@
 import { LazySwitch } from "~/lazy";
 import SettingsItem from "./item";
-import { useContext } from "solid-js";
-import { AppContext } from "~/context";
+
 import { writeConfigFile } from "~/commands";
-import { useTranslations } from "~/contexts";
+
+import { useConfig, useTranslations } from "~/contexts";
 
 const LockScreenWallpaperSwitch = () => {
-  const { config, refetchConfig } = useContext(AppContext)!;
+  const { data: config, refetch: refetchConfig } = useConfig();
   const { translate } = useTranslations();
 
   const onSwitchLockScreenWallpaper = async () => {

--- a/src/components/Settings/ThemesDirectory.tsx
+++ b/src/components/Settings/ThemesDirectory.tsx
@@ -1,13 +1,16 @@
+import { createSignal } from "solid-js";
+
+import { confirm, message, open } from "@tauri-apps/plugin-dialog";
+
 import { LazyButton, LazySpace, LazyTooltip } from "~/lazy";
 import SettingsItem from "./item";
-import { useAppContext } from "~/context";
-import { createSignal } from "solid-js";
+
 import { moveThemesDirectory, openDir } from "~/commands";
-import { confirm, message, open } from "@tauri-apps/plugin-dialog";
-import { useTranslations } from "~/contexts";
+
+import { useConfig, useTranslations } from "~/contexts";
 
 const ThemesDirectory = () => {
-  const { config, refetchConfig } = useAppContext();
+  const { data: config, refetch: refetchConfig } = useConfig();
   const { translate } = useTranslations();
 
   const [path, setPath] = createSignal(config()?.themes_directory);

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+import { useConfigState } from "~/hooks/state";
+
+interface ConfigContext {
+  data: Resource<Config>;
+  refetch: () => Config | Promise<Config | undefined> | null | undefined;
+  mutate: Setter<Config | undefined>;
+}
+
+const ConfigContext = createContext<ConfigContext>();
+
+export const ConfigProvider = (props: ParentProps) => {
+  const config = useConfigState();
+
+  return (
+    <ConfigContext.Provider value={config}>
+      {props.children}
+    </ConfigContext.Provider>
+  );
+};
+
+export const useConfig = () => {
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error("useConfig: 必须在ConfigProvider内部使用");
+  }
+  return context;
+};

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,0 @@
-export { useTranslations } from "./TranslationsContext";

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -1,0 +1,15 @@
+import type { ParentProps } from "solid-js";
+
+import { TranslationsProvider } from "./TranslationsContext";
+import { ConfigProvider } from "./ConfigContext";
+
+export const AppProvider = (props: ParentProps) => {
+  return (
+    <TranslationsProvider>
+      <ConfigProvider>{props.children}</ConfigProvider>
+    </TranslationsProvider>
+  );
+};
+
+export { useTranslations } from "./TranslationsContext";
+export { useConfig } from "./ConfigContext";

--- a/src/hooks/state/index.tsx
+++ b/src/hooks/state/index.tsx
@@ -1,0 +1,1 @@
+export { useConfigState } from "./useConfigState";

--- a/src/hooks/state/useConfigState.tsx
+++ b/src/hooks/state/useConfigState.tsx
@@ -1,0 +1,13 @@
+import { createResource } from "solid-js";
+
+import { readConfigFile } from "~/commands";
+
+export const useConfigState = () => {
+  const [data, { refetch, mutate }] = createResource<Config>(readConfigFile);
+
+  return {
+    data,
+    refetch,
+    mutate,
+  };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
+import App from "./App";
+import { AppProvider } from "~/contexts";
 import "fluent-solid/lib/index.css";
 import "./index.scss";
-import App from "./App";
-import { TranslationsProvider } from "./contexts/TranslationsContext";
 
 if (import.meta.env.MODE === "production") {
   document.addEventListener("contextmenu", (event) => event.preventDefault());
@@ -11,9 +11,9 @@ if (import.meta.env.MODE === "production") {
 
 render(
   () => (
-    <TranslationsProvider>
+    <AppProvider>
       <App />
-    </TranslationsProvider>
+    </AppProvider>
   ),
   document.getElementById("root") as HTMLElement,
 );


### PR DESCRIPTION
Move context-related logic into a centralized `AppProvider` and introduce `useConfig` hook for managing config state. This improves maintainability and reduces redundancy across components by providing a single source of truth for context and config management.