### PR TITLE
refactor(theme): modify getAppliedThemeID to accept monitorId

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,6 @@ const App = () => {
     handleChange: handleMonitorChange,
     id: monitorID,
   } = useMonitor();
-  // const { handleClosure: handleTaskClosure } = task;
   const { showSettings } = useSettings();
 
   useDark();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,8 +16,8 @@ export const checkThemeExists = async (
 export const applyTheme = async (config: Config) =>
   invoke("apply_theme", { config });
 
-export const getAppliedThemeID = async () =>
-  invoke<string | null>("get_applied_theme_id");
+export const getAppliedThemeID = async (monitorId: string) =>
+  invoke<string | null>("get_applied_theme_id", { monitorId });
 
 export const checkAutoStart = async () => invoke<boolean>("check_auto_start");
 

--- a/src/hooks/useAppInitialization.tsx
+++ b/src/hooks/useAppInitialization.tsx
@@ -1,5 +1,11 @@
 import { onMount } from "solid-js";
-import { setTitlebarColorMode, showWindow } from "~/commands";
+import {
+  getAppliedThemeID,
+  setTitlebarColorMode,
+  showWindow,
+} from "~/commands";
+import { useMonitor, useTheme } from "~/contexts";
+import { themes } from "~/themes";
 import { detectColorMode } from "~/utils/color";
 
 /**
@@ -11,6 +17,9 @@ export const useAppInitialization = (
   menuItemIndex: Accessor<number | undefined>,
   handleThemeSelection: (index: number) => void,
 ) => {
+  const { setMenuItemIndex, setAppliedThemeID } = useTheme();
+  const { id: monitorID } = useMonitor();
+
   onMount(async () => {
     await setTitlebarColorMode(detectColorMode());
 
@@ -18,5 +27,16 @@ export const useAppInitialization = (
 
     const mii = menuItemIndex();
     if (mii !== undefined) handleThemeSelection(mii);
+
+    const applied_theme_id = await getAppliedThemeID(monitorID());
+    if (applied_theme_id) {
+      const themeIndex = themes.findIndex((t) => t.id === applied_theme_id);
+      if (themeIndex !== -1) {
+        setMenuItemIndex(themeIndex);
+        handleThemeSelection(themeIndex);
+        setAppliedThemeID(applied_theme_id);
+        return;
+      }
+    }
   });
 };


### PR DESCRIPTION
The getAppliedThemeID function now accepts a monitorId parameter to retrieve the theme ID specific to a monitor. This change allows for more granular control over theme application based on the monitor. Additionally, the initialization hook has been updated to use this new parameter to set the applied theme ID correctly during app startup.