### PR TITLE
fix: handle update failure with error message and dialog closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dwall"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "dirs",
  "regex",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "dwall-settings"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "dirs",
  "dwall",

--- a/src/components/Update/UpdateDialog.tsx
+++ b/src/components/Update/UpdateDialog.tsx
@@ -4,33 +4,41 @@ import { createSignal, onMount } from "solid-js";
 import { LazyProgress } from "~/lazy";
 import Dialog from "../Dialog";
 
-import { useTranslations } from "~/contexts";
+import { useTranslations, useUpdate } from "~/contexts";
+import { message } from "@tauri-apps/plugin-dialog";
 
 interface UpdateDialogProps {
   update: Update;
 }
 
 const UpdateDialog = (props: UpdateDialogProps) => {
-  const { translate } = useTranslations();
+  const { translate, translateErrorMessage } = useTranslations();
+  const { setShowUpdateDialog } = useUpdate();
 
   const [total, setTotal] = createSignal<number | undefined>();
   const [downloaded, setDownloaded] = createSignal<number | undefined>();
 
   onMount(async () => {
-    await props.update.downloadAndInstall((event) => {
-      switch (event.event) {
-        case "Started":
-          setTotal(event.data.contentLength ?? 0);
-          break;
-        case "Progress":
-          setDownloaded((prev) => (prev ?? 0) + event.data.chunkLength);
-          break;
-        case "Finished":
-          break;
-      }
-    });
-
-    await relaunch();
+    try {
+      await props.update.downloadAndInstall((event) => {
+        switch (event.event) {
+          case "Started":
+            setTotal(event.data.contentLength ?? 0);
+            break;
+          case "Progress":
+            setDownloaded((prev) => (prev ?? 0) + event.data.chunkLength);
+            break;
+          case "Finished":
+            break;
+        }
+      });
+      await relaunch();
+    } catch (error) {
+      await message(translateErrorMessage("message-update-failed", error), {
+        kind: "error",
+      });
+      setShowUpdateDialog(false);
+    }
   });
 
   return (


### PR DESCRIPTION
Add error handling to the update process to display a user-friendly error message and close the update dialog when an update fails. This improves the user experience by providing clear feedback in case of errors.