### PR TITLE
feat(position): add timeout and caching for geolocation

### DIFF
--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -45,6 +45,10 @@ pub enum DwallError {
     /// Monitor related error
     #[error("Monitor operation failed: {0}")]
     Monitor(#[from] crate::monitor::error::MonitorError),
+
+    /// Timeout error
+    #[error("Operation timed out: {0}")]
+    TimeoutError(String),
 }
 
 /// Registry operation related errors


### PR DESCRIPTION
Introduce timeout handling and caching mechanism for geolocation requests to improve reliability and performance. The `get_geo_position` function is now asynchronous, and a timeout error is added to handle long-running requests. The `PositionManager` now caches the position for a configurable duration to reduce redundant API calls.