### PR TITLE
refactor(config): remove lifetime annotations and simplify Config struct

### DIFF
--- a/daemon/src/theme/mod.rs
+++ b/daemon/src/theme/mod.rs
@@ -23,7 +23,7 @@ pub enum ThemeError {
 }
 
 /// Applies a theme and starts a background task for periodic wallpaper updates
-pub async fn apply_theme(config: Config<'_>) -> DwallResult<()> {
+pub async fn apply_theme(config: Config) -> DwallResult<()> {
     let theme_processor = ThemeProcessor::new(&config);
 
     theme_processor.start_update_loop().await

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
@@ -96,7 +95,7 @@ impl<'a> ThemeDownloader<'a> {
     /// Download theme zip file
     pub async fn download_theme(
         &self,
-        config: &Config<'_>,
+        config: &Config,
         theme_id: &str,
     ) -> DwallSettingsResult<PathBuf> {
         // Check if theme is already being downloaded
@@ -333,10 +332,10 @@ impl<'a> ThemeDownloader<'a> {
 }
 
 #[tauri::command]
-pub async fn download_theme_and_extract<'a>(
+pub async fn download_theme_and_extract(
     window: WebviewWindow,
-    config: Config<'a>,
-    theme_id: Cow<'a, str>,
+    config: Config,
+    theme_id: &str,
 ) -> DwallSettingsResult<()> {
     let downloader = ThemeDownloader::new(&window);
 

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -1,5 +1,4 @@
-use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use dwall::config::{write_config_file, Config};
 use tokio::fs;
@@ -62,10 +61,7 @@ impl From<ThemeDirectoryMoveError> for DwallSettingsResult<()> {
 }
 
 #[tauri::command]
-pub async fn move_themes_directory(
-    config: Config<'_>,
-    dir_path: Cow<'_, Path>,
-) -> DwallSettingsResult<()> {
+pub async fn move_themes_directory(config: Config, dir_path: PathBuf) -> DwallSettingsResult<()> {
     // Validate input parameters
     if dir_path.to_path_buf().as_path() == config.themes_directory() {
         debug!("Source and destination paths are the same. No move necessary.");
@@ -106,7 +102,7 @@ pub async fn move_themes_directory(
 }
 
 /// Validates the directory move operation
-fn validate_directory_move(config: &Config<'_>, destination: &Path) -> DwallSettingsResult<()> {
+fn validate_directory_move(config: &Config, destination: &Path) -> DwallSettingsResult<()> {
     debug!("Performing pre-move directory validation");
 
     // Check if destination directory already exists
@@ -136,10 +132,7 @@ fn validate_directory_move(config: &Config<'_>, destination: &Path) -> DwallSett
 }
 
 /// Prepares the new configuration
-async fn prepare_new_config<'a>(
-    config: &Config<'a>,
-    new_path: &'a Path,
-) -> DwallSettingsResult<()> {
+async fn prepare_new_config(config: &Config, new_path: &Path) -> DwallSettingsResult<()> {
     debug!("Preparing new configuration with updated themes directory");
 
     let new_config = config.with_themes_directory(new_path);
@@ -152,7 +145,7 @@ async fn prepare_new_config<'a>(
 
 /// Performs the actual themes directory move
 async fn perform_themes_directory_move(
-    config: &Config<'_>,
+    config: &Config,
     destination: &Path,
 ) -> Result<(), ThemeDirectoryMoveError> {
     let source = config.themes_directory();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,7 +113,7 @@ async fn get_applied_theme_id(monitor_id: &str) -> DwallSettingsResult<Option<St
 }
 
 #[tauri::command]
-async fn read_config_file<'a>() -> DwallSettingsResult<Config<'a>> {
+async fn read_config_file() -> DwallSettingsResult<Config> {
     trace!("Reading configuration file");
     match dwall::config::read_config_file().await {
         Ok(config) => {
@@ -128,7 +128,7 @@ async fn read_config_file<'a>() -> DwallSettingsResult<Config<'a>> {
 }
 
 #[tauri::command]
-async fn write_config_file(config: Config<'_>) -> DwallSettingsResult<()> {
+async fn write_config_file(config: Config) -> DwallSettingsResult<()> {
     trace!("Writing configuration file");
     match dwall_write_config(&config).await {
         Ok(_) => {
@@ -143,7 +143,7 @@ async fn write_config_file(config: Config<'_>) -> DwallSettingsResult<()> {
 }
 
 #[tauri::command]
-async fn apply_theme(config: Config<'_>) -> DwallSettingsResult<()> {
+async fn apply_theme(config: Config) -> DwallSettingsResult<()> {
     trace!("Starting theme application process");
 
     match kill_daemon() {


### PR DESCRIPTION
Removed lifetime annotations from the Config struct and related functions to simplify the codebase. This change eliminates unnecessary complexity and improves maintainability by using owned types like String and PathBuf instead of Cow. The modifications ensure that the functionality remains unchanged while making the code easier to understand and work with.