### PR TITLE
feat(i18n): add GitHub star prompt and toast message

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -34,6 +34,7 @@ pub(super) const TOOLTIP_SETTINGS: &str = "tooltip-settings";
 pub(super) const MESSAGE_CHANGE_THEMES_DIRECTORY: &str = "message-change-themes-directory";
 pub(super) const MESSAGE_DISABLE_STARTUP_FAILED: &str = "message-disable-startup-failed";
 pub(super) const MESSAGE_DOWNLOAD_FAILED: &str = "message-download-faild";
+pub(super) const MESSAGE_GITHUB_STAR: &str = "message-github-star";
 pub(super) const MESSAGE_INVALID_NUMBER_INPUT: &str = "message-invalid-number-input";
 pub(super) const MESSAGE_LOCATION_PERMISSION: &str = "message-location-permission";
 pub(super) const MESSAGE_MANUAL_COORDINATES_SAVED: &str = "message-coordinates-saved";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -103,6 +103,12 @@ impl TranslationMap for EnglishUSTranslations {
             },
         );
         translations.insert(
+            MESSAGE_GITHUB_STAR,
+            TranslationValue::Text(
+                "If this application has helped you, please give us a star on GitHub to support the open-source project: ",
+            ),
+        );
+        translations.insert(
             MESSAGE_INVALID_NUMBER_INPUT,
             TranslationValue::Text("Please enter a valid number."),
         );

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -87,6 +87,12 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             },
         );
         translations.insert(
+            MESSAGE_GITHUB_STAR,
+            TranslationValue::Text(
+                "若本程序帮助到了你，请去 Github 为本项目标星，谢谢支持开源项目：",
+            ),
+        );
+        translations.insert(
             MESSAGE_INVALID_NUMBER_INPUT,
             TranslationValue::Text("请输入有效的数字"),
         );

--- a/src/App.scss
+++ b/src/App.scss
@@ -86,3 +86,19 @@
     border-radius: 4px;
   }
 }
+
+.toast-message-link-like-button {
+  background-color: transparent;
+  border: none;
+  text-decoration: underline;
+  color: var(--colorBrandForegroundLink);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--colorBrandForegroundLinkHover);
+  }
+
+  &:active {
+    color: var(--colorBrandForegroundLinkPressed);
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ const App = () => {
   useDark();
   useColorMode();
 
-  useAppInitialization(menuItemIndex, handleThemeSelection);
+  useAppInitialization(translate, menuItemIndex, handleThemeSelection);
 
   return (
     <>

--- a/src/hooks/useAppInitialization.tsx
+++ b/src/hooks/useAppInitialization.tsx
@@ -1,9 +1,11 @@
+import { open } from "@tauri-apps/plugin-shell";
 import { onMount } from "solid-js";
 import {
   getAppliedThemeID,
   setTitlebarColorMode,
   showWindow,
 } from "~/commands";
+import { showToast } from "~/components/Toast";
 import { useMonitor, useTheme } from "~/contexts";
 import { themes } from "~/themes";
 import { detectColorMode } from "~/utils/color";
@@ -14,11 +16,16 @@ import { detectColorMode } from "~/utils/color";
  * @param handleThemeSelection Function to handle theme selection
  */
 export const useAppInitialization = (
+  translate: (key: TranslationKey, params?: Record<string, string>) => string,
   menuItemIndex: Accessor<number | undefined>,
   handleThemeSelection: (index: number) => void,
 ) => {
   const { setMenuItemIndex, setAppliedThemeID } = useTheme();
   const { id: monitorID } = useMonitor();
+
+  const openGithubRepository = async () => {
+    await open("https://github.com/dwall-rs/dwall");
+  };
 
   onMount(async () => {
     await setTitlebarColorMode(detectColorMode());
@@ -27,6 +34,23 @@ export const useAppInitialization = (
 
     const mii = menuItemIndex();
     if (mii !== undefined) handleThemeSelection(mii);
+
+    showToast({
+      message: (
+        <span>
+          {translate("message-github-star")}
+          <button
+            type="button"
+            class="toast-message-link-like-button"
+            onClick={openGithubRepository}
+          >
+            dwall
+          </button>
+        </span>
+      ),
+      position: "top-right",
+      duration: 5000,
+    });
 
     const applied_theme_id = await getAppliedThemeID(monitorID());
     if (applied_theme_id) {

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -23,6 +23,7 @@ type TranslationKey =
   | "message-change-themes-directory"
   | "message-disable-startup-failed"
   | "message-download-faild"
+  | "message-github-star"
   | "message-invalid-number-input"
   | "message-location-permission"
   | "message-coordinates-saved"


### PR DESCRIPTION
Add a new translation key "message-github-star" to encourage users to star the project on GitHub. This is displayed as a toast message during app initialization, including a button that links to the GitHub repository. The toast message is styled with a link-like appearance for better user interaction.