### PR TITLE
chore: increase toast notification duration to 10000ms

### DIFF
--- a/src/hooks/useAppInitialization.tsx
+++ b/src/hooks/useAppInitialization.tsx
@@ -49,7 +49,7 @@ export const useAppInitialization = (
         </span>
       ),
       position: "top-right",
-      duration: 5000,
+      duration: 10000,
     });
 
     const applied_theme_id = await getAppliedThemeID(monitorID());


### PR DESCRIPTION
The toast notification duration was increased from 5000ms to 10000ms to ensure users have sufficient time to read the message, especially for longer notifications.