### PR TITLE
feat(toast): add support for customizable max-width in Toast component

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -22,6 +22,7 @@ const Toast: Component<ToastProps> = (props) => {
       position: "top" as NonNullable<ToastProps["position"]>,
       type: "info" as NonNullable<ToastProps["type"]>,
       closable: true,
+      maxWidth: 400,
     },
     props,
   );
@@ -67,6 +68,7 @@ const Toast: Component<ToastProps> = (props) => {
       <ToastContainer
         position={merged.position}
         zIndex={merged.zIndex}
+        maxWidth={merged.maxWidth}
         style={props.style}
       >
         <ToastContent

--- a/src/components/Toast/ToastContainer.tsx
+++ b/src/components/Toast/ToastContainer.tsx
@@ -17,6 +17,10 @@ const ToastContainer: Component<ToastContainerProps> = (props) => {
         style={{
           ...props.style,
           "z-index": props.zIndex,
+          "--fui-toast-max-width":
+            typeof props.maxWidth === "number"
+              ? `${props.maxWidth}px`
+              : props.maxWidth,
         }}
         role="alert"
         aria-live="assertive"

--- a/src/components/Toast/index.scss
+++ b/src/components/Toast/index.scss
@@ -6,9 +6,11 @@
 }
 
 .fluent-toast {
+  --fui-toast-max-width: 350px;
+
   position: fixed;
   z-index: 1100;
-  max-width: 350px;
+  max-width: var(--fui-toast-max-width);
   padding: 0;
   pointer-events: auto;
   animation-duration: 0.3s;

--- a/src/components/Toast/types.ts
+++ b/src/components/Toast/types.ts
@@ -38,6 +38,8 @@ export interface ToastProps
   maxCount?: number;
   /** Custom z-index value */
   zIndex?: number;
+  /** Custom max-width value */
+  maxWidth?: number | string;
   /** Custom CSS styles */
   style?: JSX.CSSProperties;
 }
@@ -58,6 +60,7 @@ export interface ToastContentProps {
 export interface ToastContainerProps {
   position: ToastPosition;
   zIndex?: number;
+  maxWidth?: number | string;
   style?: JSX.CSSProperties;
   children: JSX.Element;
 }


### PR DESCRIPTION
Introduce a new `maxWidth` prop to allow users to customize the maximum width of the Toast component. This enhances flexibility by enabling dynamic width adjustments based on user requirements. The default max-width is set to 400px for consistency.