### PR TITLE
feat(i18n): add translation key for download cancelled message

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -33,6 +33,7 @@ pub(super) const TOOLTIP_SETTINGS: &str = "tooltip-settings";
 // ---------------- messages ----------------
 pub(super) const MESSAGE_CHANGE_THEMES_DIRECTORY: &str = "message-change-themes-directory";
 pub(super) const MESSAGE_DISABLE_STARTUP_FAILED: &str = "message-disable-startup-failed";
+pub(super) const MESSAGE_DOWNLOAD_CANCELLED: &str = "message-download-cancelled";
 pub(super) const MESSAGE_DOWNLOAD_FAILED: &str = "message-download-faild";
 pub(super) const MESSAGE_GITHUB_STAR: &str = "message-github-star";
 pub(super) const MESSAGE_INVALID_NUMBER_INPUT: &str = "message-invalid-number-input";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -95,6 +95,10 @@ impl TranslationMap for EnglishUSTranslations {
             },
         );
         translations.insert(
+            MESSAGE_DOWNLOAD_CANCELLED,
+            TranslationValue::Text("Download cancelled"),
+        );
+        translations.insert(
             MESSAGE_DOWNLOAD_FAILED,
             TranslationValue::Template {
                 template:

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -80,6 +80,10 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             },
         );
         translations.insert(
+            MESSAGE_DOWNLOAD_CANCELLED,
+            TranslationValue::Text("已取消下载"),
+        );
+        translations.insert(
             MESSAGE_DOWNLOAD_FAILED,
             TranslationValue::Template {
                 template: "{{error}}\n\n具体错误请查看日志文件：dwall_settings_lib.log",

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -22,6 +22,7 @@ type TranslationKey =
   | "tooltip-settings"
   | "message-change-themes-directory"
   | "message-disable-startup-failed"
+  | "message-download-cancelled"
   | "message-download-faild"
   | "message-github-star"
   | "message-invalid-number-input"


### PR DESCRIPTION
Add a new translation key "message-download-cancelled" to support displaying a message when a download is cancelled. This includes updates to the TypeScript definition, Rust locale files for both English and Simplified Chinese, and the Rust i18n keys file.