### PR TITLE
refactor(Download): remove unused CSS and improve error handling

### DIFF
--- a/src/components/Download/index.scss
+++ b/src/components/Download/index.scss
@@ -12,22 +12,3 @@
   position: absolute;
   bottom: 36px;
 }
-
-.cancel-download-btn {
-  padding: 8px 16px;
-  background-color: #f44336;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 500;
-  transition: background-color 0.3s;
-
-  &:hover {
-    background-color: #d32f2f;
-  }
-
-  &:active {
-    background-color: #b71c1c;
-  }
-}


### PR DESCRIPTION
- Removed unused `.cancel-download-btn` CSS class as the button styling is now handled by `LazyButton`.
- Improved error handling by using `translateErrorMessage` for consistent error messages and added toast notifications for download cancellation and warnings.