### PR TITLE
feat(Toast): add pause and resume functionality on mouse hover

### DIFF
--- a/src/components/Toast/ToastContainer.tsx
+++ b/src/components/Toast/ToastContainer.tsx
@@ -24,6 +24,8 @@ const ToastContainer: Component<ToastContainerProps> = (props) => {
         }}
         role="alert"
         aria-live="assertive"
+        onMouseEnter={() => props.onMouseEnter?.()}
+        onMouseLeave={() => props.onMouseLeave?.()}
       >
         {props.children}
       </div>

--- a/src/components/Toast/types.ts
+++ b/src/components/Toast/types.ts
@@ -12,6 +12,8 @@ export type ToastPosition =
 
 export type ToastRef = HTMLDivElement & {
   close: () => void;
+  pause: () => void;
+  resume: () => void;
 };
 
 export interface ToastProps
@@ -63,6 +65,8 @@ export interface ToastContainerProps {
   maxWidth?: number | string;
   style?: JSX.CSSProperties;
   children: JSX.Element;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 }
 
 export interface ToastInstance {


### PR DESCRIPTION
Introduce pause and resume functionality for Toast timers when the user hovers over the Toast. This improves user experience by allowing users to read the message without it disappearing prematurely. The changes include adding `onMouseEnter` and `onMouseLeave` handlers, updating the `ToastRef` type, and replacing `useTimeout` with `usePausableTimeout` for better control over the timer.