### PR TITLE
feat(i18n): add error message for theme application failure

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -31,6 +31,7 @@ pub(super) const TOOLTIP_OPEN_THEMES_DIRECTORY: &str = "tooltip-open-themes-dire
 pub(super) const TOOLTIP_SETTINGS: &str = "tooltip-settings";
 
 // ---------------- messages ----------------
+pub(super) const MESSAGE_APPLY_THEME_FAILED: &str = "message-apply-theme-failed";
 pub(super) const MESSAGE_CHANGE_THEMES_DIRECTORY: &str = "message-change-themes-directory";
 pub(super) const MESSAGE_DISABLE_STARTUP_FAILED: &str = "message-disable-startup-failed";
 pub(super) const MESSAGE_DOWNLOAD_CANCELLED: &str = "message-download-cancelled";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -81,6 +81,13 @@ impl TranslationMap for EnglishUSTranslations {
 
         // messages
         translations.insert(
+            MESSAGE_APPLY_THEME_FAILED,
+            TranslationValue::Template {
+                template: "Failed to apply theme: \n{{error}}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
             MESSAGE_CHANGE_THEMES_DIRECTORY,
             TranslationValue::Template {
                 template: "Change the themes directory to: {{newThemesDirectory}}?",

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -66,6 +66,13 @@ impl TranslationMap for ChineseSimplifiedTranslations {
 
         // messages
         translations.insert(
+            MESSAGE_APPLY_THEME_FAILED,
+            TranslationValue::Template {
+                template: "应用主题失败: \n{{error}}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
             MESSAGE_CHANGE_THEMES_DIRECTORY,
             TranslationValue::Template {
                 template: "修改主题文件夹为：{{newThemesDirectory}}？",

--- a/src/components/ThemeActions.tsx
+++ b/src/components/ThemeActions.tsx
@@ -21,9 +21,9 @@ export const ThemeActions = () => {
 
   const [spinning, setSpinning] = createSignal(false);
 
-  const onApply = () => {
+  const onApply = async () => {
     setSpinning(true);
-    theme.handleThemeApplication(monitorID, monitors);
+    await theme.handleThemeApplication(monitorID, monitors);
     setSpinning(false);
   };
 

--- a/src/hooks/theme/useThemeApplication.tsx
+++ b/src/hooks/theme/useThemeApplication.tsx
@@ -1,4 +1,6 @@
+import { message } from "@tauri-apps/plugin-dialog";
 import { applyTheme } from "~/commands";
+import { useTranslations } from "~/contexts";
 
 /**
  * Theme application management Hook, used to handle theme application and task closure
@@ -16,6 +18,8 @@ export const useThemeApplication = (
   checkLocationPermission: () => Promise<boolean>,
   setAppliedThemeID: (id?: string) => void,
 ) => {
+  const { translateErrorMessage } = useTranslations();
+
   // Handle theme application
   const handleThemeApplication = async (
     monitorID: Accessor<string>,
@@ -60,7 +64,9 @@ export const useThemeApplication = (
       refetchConfig();
       setAppliedThemeID(theme.id);
     } catch (e) {
-      console.error("Failed to apply theme:", e);
+      message(translateErrorMessage("message-apply-theme-failed", e), {
+        kind: "error",
+      });
     }
   };
 

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -20,6 +20,7 @@ type TranslationKey =
   | "tooltip-new-version-available"
   | "tooltip-open-themes-directory"
   | "tooltip-settings"
+  | "message-apply-theme-failed"
   | "message-change-themes-directory"
   | "message-disable-startup-failed"
   | "message-download-cancelled"


### PR DESCRIPTION
Introduce a new translation key `message-apply-theme-failed` to handle and display error messages when theme application fails. This improves user feedback by providing a clear error message in both English and Chinese locales. Additionally, the `onApply` function in `ThemeActions.tsx` is updated to handle asynchronous theme application, ensuring the UI reflects the loading state correctly.