### PR TITLE
build: add devtools feature and stage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start:dev": "cargo build -p dwall --features log-color && cross-env RUST_BACKTRACE=1 tauri dev --features log-color",
     "check": "biome check --write src",
     "dev": "bun run start:dev",
+    "stage": "cargo build -r -p dwall --features log-color && cross-env RUST_BACKTRACE=1 tauri dev --features log-color devtools --release",
     "test": "vitest"
   },
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,3 +55,4 @@ tauri-plugin-process = "2"
 [features]
 default = []
 log-color = ["dwall/log-color"]
+devtools = ["tauri/devtools"]


### PR DESCRIPTION
This commit introduces the `devtools` feature in the Tauri configuration and adds a `stage` script to the package.json for building and running the application in release mode with devtools enabled. These changes facilitate easier debugging and testing during development.