### PR TITLE
fix: add URL to error logs for better debugging

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -241,7 +241,7 @@ pub async fn get_or_save_cached_thumbnails(
             let _ = cell.set(path.clone());
         }
         Err(e) => {
-            error!(error = ?e, "Failed to cache image");
+            error!(error = ?e, url = url, "Failed to cache image");
             // Don't cache errors
         }
     }

--- a/src-tauri/src/download/http_service.rs
+++ b/src-tauri/src/download/http_service.rs
@@ -73,6 +73,7 @@ impl HttpDownloadService {
             if let StatusCode::NOT_FOUND = response.status() {
                 error!(
                     theme_id = theme_id,
+                    url = %url,
                     "The theme does not exist on the server"
                 );
                 return Err(DownloadError::NotFound(theme_id.to_string()).into());


### PR DESCRIPTION
Include the URL in error logs when caching images and downloading themes to provide more context for debugging failures.