### PR TITLE
refactor: integrate ToastProvider and useToast hook across components

### DIFF
--- a/src/components/Download/index.tsx
+++ b/src/components/Download/index.tsx
@@ -2,7 +2,7 @@ import { createEffect, createSignal, onMount, Show } from "solid-js";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { message } from "@tauri-apps/plugin-dialog";
 import { LazyButton, LazyProgress } from "~/lazy";
-import { toast } from "~/components/Toast";
+import { useToast } from "~/components//Toast";
 import { downloadThemeAndExtract, cancelThemeDownload } from "~/commands";
 import { useConfig, useTheme, useTranslations } from "~/contexts";
 import "./index.scss";
@@ -22,6 +22,7 @@ const Download = () => {
   const [percent, setPercent] = createSignal<number>();
   const [isCancelling, setIsCancelling] = createSignal(false);
   const [warning, setWarning] = createSignal<string>();
+  const toast = useToast();
 
   const onFinished = () => {
     theme.setDownloadThemeID();
@@ -62,7 +63,9 @@ const Download = () => {
     } catch (e) {
       // 检查是否是取消下载导致的错误
       if (String(e).includes("Download cancelled")) {
-        toast.success("下载已取消", { closable: false });
+        toast.success("下载已取消", {
+          closable: false,
+        });
       } else {
         message(translateErrorMessage("message-download-faild", e), {
           title: translate("title-download-faild"),
@@ -78,7 +81,11 @@ const Download = () => {
 
   createEffect(
     () =>
-      warning() && toast.warning(warning(), { duration: 10000, maxWidth: 480 }),
+      warning() &&
+      toast.warning(warning(), {
+        duration: 10000,
+        maxWidth: 480,
+      }),
   );
 
   return (

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -7,22 +7,25 @@ import { MonitorProvider } from "./MonitorContext";
 import { UpdateProvider } from "./UpdateContext";
 import { SettingsProvider } from "./SettingsContext";
 import { TaskProvider } from "./TaskContext";
+import { ToastProvider } from "~/components/Toast";
 
 export const AppProvider = (props: ParentProps) => {
   return (
-    <TranslationsProvider>
-      <ConfigProvider>
-        <ThemeProvider>
-          <MonitorProvider>
-            <SettingsProvider>
-              <UpdateProvider>
-                <TaskProvider>{props.children}</TaskProvider>
-              </UpdateProvider>
-            </SettingsProvider>
-          </MonitorProvider>
-        </ThemeProvider>
-      </ConfigProvider>
-    </TranslationsProvider>
+    <ToastProvider>
+      <TranslationsProvider>
+        <ConfigProvider>
+          <ThemeProvider>
+            <MonitorProvider>
+              <SettingsProvider>
+                <UpdateProvider>
+                  <TaskProvider>{props.children}</TaskProvider>
+                </UpdateProvider>
+              </SettingsProvider>
+            </MonitorProvider>
+          </ThemeProvider>
+        </ConfigProvider>
+      </TranslationsProvider>
+    </ToastProvider>
   );
 };
 

--- a/src/hooks/useAppInitialization.tsx
+++ b/src/hooks/useAppInitialization.tsx
@@ -5,7 +5,7 @@ import {
   setTitlebarColorMode,
   showWindow,
 } from "~/commands";
-import { showToast } from "~/components/Toast";
+import { useToast } from "~/components/Toast";
 import { useMonitor, useTheme } from "~/contexts";
 import { themes } from "~/themes";
 import { detectColorMode } from "~/utils/color";
@@ -22,6 +22,7 @@ export const useAppInitialization = (
 ) => {
   const { setMenuItemIndex, setAppliedThemeID } = useTheme();
   const { id: monitorID } = useMonitor();
+  const toast = useToast();
 
   const openGithubRepository = async () => {
     await open("https://github.com/dwall-rs/dwall");
@@ -35,22 +36,22 @@ export const useAppInitialization = (
     const mii = menuItemIndex();
     if (mii !== undefined) handleThemeSelection(mii);
 
-    showToast({
-      message: (
-        <span>
-          {translate("message-github-star")}
-          <button
-            type="button"
-            class="toast-message-link-like-button"
-            onClick={openGithubRepository}
-          >
-            dwall
-          </button>
-        </span>
-      ),
-      position: "top-right",
-      duration: 10000,
-    });
+    toast.info(
+      <span>
+        {translate("message-github-star")}
+        <button
+          type="button"
+          class="toast-message-link-like-button"
+          onClick={openGithubRepository}
+        >
+          dwall
+        </button>
+      </span>,
+      {
+        position: "top-right",
+        duration: 5000,
+      },
+    );
 
     const applied_theme_id = await getAppliedThemeID(monitorID());
     if (applied_theme_id) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -31,6 +31,7 @@
 
 body {
   overflow: hidden;
+  margin: 0;
 }
 
 #root {


### PR DESCRIPTION
Refactor the codebase to use the ToastProvider context and useToast hook for consistent toast notifications. This improves maintainability and reduces direct imports of the toast utility. Additionally, set body margin to 0 to prevent unwanted spacing.