### PR TITLE
feat(i18n): add file size warning message for download progress

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -36,6 +36,7 @@ pub(super) const MESSAGE_CHANGE_THEMES_DIRECTORY: &str = "message-change-themes-
 pub(super) const MESSAGE_DISABLE_STARTUP_FAILED: &str = "message-disable-startup-failed";
 pub(super) const MESSAGE_DOWNLOAD_CANCELLED: &str = "message-download-cancelled";
 pub(super) const MESSAGE_DOWNLOAD_FAILED: &str = "message-download-faild";
+pub(super) const MESSAGE_FILE_SIZE_WARNING: &str = "message-file-size-warning";
 pub(super) const MESSAGE_GITHUB_STAR: &str = "message-github-star";
 pub(super) const MESSAGE_INVALID_NUMBER_INPUT: &str = "message-invalid-number-input";
 pub(super) const MESSAGE_LOCATION_PERMISSION: &str = "message-location-permission";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -114,6 +114,12 @@ impl TranslationMap for EnglishUSTranslations {
             },
         );
         translations.insert(
+            MESSAGE_FILE_SIZE_WARNING,
+            TranslationValue::Text(
+                "Unable to calculate download progress due to failure in getting file size. Please switch to a Github mirror template that supports forwarding response headers",
+            ),
+        );
+        translations.insert(
             MESSAGE_GITHUB_STAR,
             TranslationValue::Text(
                 "If this application has helped you, please give us a star on GitHub to support the open-source project: ",

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -98,6 +98,12 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             },
         );
         translations.insert(
+            MESSAGE_FILE_SIZE_WARNING,
+            TranslationValue::Text(
+                "因无法获取文件大小导致无法计算下载进度，请更换支持转发响应头的 Github 镜像模板",
+            ),
+        );
+        translations.insert(
             MESSAGE_GITHUB_STAR,
             TranslationValue::Text(
                 "若本程序帮助到了你，请去 Github 为本项目标星，谢谢支持开源项目：",

--- a/src/components/Download/index.tsx
+++ b/src/components/Download/index.tsx
@@ -35,7 +35,7 @@ const Download = () => {
     setIsCancelling(true);
     try {
       await cancelThemeDownload(theme.downloadThemeID()!);
-      // 取消操作已发送，但实际取消会在后端处理
+      // Cancellation request sent, but actual cancellation will be handled by backend
     } catch (e) {
       message(translateErrorMessage("message-download-faild", e), {
         title: translate("title-download-faild"),
@@ -50,9 +50,7 @@ const Download = () => {
       (e) => {
         const { total_bytes, downloaded_bytes } = e.payload;
         if (total_bytes === 0) {
-          setWarning(
-            "因无法获取文件大小导致无法计算下载进度，请更换支持转发响应头的 Github 镜像模板",
-          );
+          setWarning(translate("message-file-size-warning"));
           setPercent(100);
         } else {
           setPercent(Math.round((downloaded_bytes / total_bytes) * 1000) / 10);
@@ -63,9 +61,9 @@ const Download = () => {
     try {
       await downloadThemeAndExtract(config()!, theme.downloadThemeID()!);
     } catch (e) {
-      // 检查是否是取消下载导致的错误
+      // Check if the error is caused by download cancellation
       if (String(e).includes("Download cancelled")) {
-        toast.success("下载已取消", {
+        toast.success(translate("message-download-cancelled"), {
           closable: false,
         });
       } else {

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -25,6 +25,7 @@ type TranslationKey =
   | "message-disable-startup-failed"
   | "message-download-cancelled"
   | "message-download-faild"
+  | "message-file-size-warning"
   | "message-github-star"
   | "message-invalid-number-input"
   | "message-location-permission"


### PR DESCRIPTION
Add a new translation key `message-file-size-warning` to handle cases where the file size cannot be retrieved during downloads. This ensures users are informed about the issue and guided to use a compatible Github mirror template. The message is added to both English and Chinese locales and integrated into the download component.