### PR TITLE
ci: add refactor section to changelog configuration

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -5,6 +5,10 @@
       "labels": ["feature"]
     },
     {
+      "title": "## ⚙️ Refactors",
+      "labels": ["refactor"]
+    },
+    {
       "title": "## 🚀 Enhancements",
       "labels": ["enhancement"]
     },


### PR DESCRIPTION
This commit introduces a new section in the changelog configuration to categorize refactor-related changes, improving the organization and readability of the changelog.