### PR TITLE
refactor(Select): replace icon and adjust border styles

### DIFF
--- a/src/components/Select/index.module.scss
+++ b/src/components/Select/index.module.scss
@@ -9,8 +9,9 @@
 .selectWrapper {
   display: flex;
   align-items: center;
-  border: 1px solid var(--colorNeutralStroke1);
   border-radius: var(--borderRadiusMedium, 4px);
+  border: 1px solid var(--colorNeutralStroke1);
+  border-bottom-color: var(--colorNeutralStrokeAccessible);
   padding: 0 8px 0 12px;
   height: 32px;
   background: var(--colorNeutralBackground1);
@@ -23,7 +24,6 @@
   line-height: var(--lineHeightBase300, 20px);
 
   &:hover {
-    border-color: var(--colorNeutralStrokeAccessible);
     background: var(--colorNeutralBackground1Hover);
   }
 
@@ -47,7 +47,6 @@
   }
 
   &.focused {
-    border-color: var(--colorNeutralStrokeAccessible);
     outline: transparent solid 2px;
 
     &:after {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -7,7 +7,7 @@ import {
   Show,
   type Component,
 } from "solid-js";
-import { BiSolidChevronDown } from "solid-icons/bi";
+import { VsChevronDown } from "solid-icons/vs";
 import type { SelectProps, SelectOption } from "./types";
 import InputContainer from "./InputContainer";
 import styles from "./index.module.scss";
@@ -202,7 +202,7 @@ const Select: Component<SelectProps> = (props) => {
           <div class={styles.value}>{getSelectedLabel()}</div>
         </Show>
         <div class={arrowClass()}>
-          <BiSolidChevronDown size={16} />
+          <VsChevronDown size={16} />
         </div>
 
         <div


### PR DESCRIPTION
Replace BiSolidChevronDown with VsChevronDown for consistency with the design system. Adjust border styles to improve visual hierarchy and accessibility by setting a distinct bottom border color and removing redundant hover and focus border color changes.