### PR TITLE
refactor(daemon): simplify daemon spawning logic by removing debug mode check

### DIFF
--- a/src-tauri/src/theme.rs
+++ b/src-tauri/src/theme.rs
@@ -1,11 +1,13 @@
 use std::{
     fs::File,
     io::{BufReader, Read},
+    os::windows::process::CommandExt,
     process::Command,
 };
 
 use serde::Deserialize;
 use serde_json::Value;
+use windows::Win32::System::Threading::CREATE_NO_WINDOW;
 
 use crate::{error::DwallSettingsResult, DAEMON_EXE_PATH, DWALL_CONFIG_DIR};
 
@@ -67,51 +69,19 @@ pub fn read_daemon_error_log() -> Option<String> {
 }
 
 pub fn spawn_apply_daemon() -> DwallSettingsResult<()> {
-    let daemon_path = DAEMON_EXE_PATH.get().unwrap().to_str().unwrap();
+    let daemon_path = DAEMON_EXE_PATH.get().unwrap().as_os_str();
 
-    #[cfg(debug_assertions)]
+    match Command::new(daemon_path)
+        .creation_flags(CREATE_NO_WINDOW.0)
+        .spawn()
     {
-        use std::io::BufRead;
-        use std::process::Stdio;
-
-        info!("Debug mode: spawning daemon with visible output");
-        let stdout = Command::new(daemon_path)
-            .stdout(Stdio::piped())
-            .spawn()
-            .map_err(|e| {
-                error!(error = ?e, path = %daemon_path, "Failed to spawn daemon");
-                e
-            })?
-            .stdout
-            .expect("Could not capture standard output.");
-
-        let reader = BufReader::new(stdout);
-
-        for line in reader.lines() {
-            let line = line?;
-            println!("{}", line);
+        Ok(handle) => {
+            info!(pid = handle.id(), "Spawned daemon using subprocess");
+            Ok(())
         }
-
-        Ok(())
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        use std::os::windows::process::CommandExt;
-        use windows::Win32::System::Threading::CREATE_NO_WINDOW;
-
-        match Command::new(daemon_path)
-            .creation_flags(CREATE_NO_WINDOW.0)
-            .spawn()
-        {
-            Ok(handle) => {
-                info!(pid = handle.id(), "Spawned daemon using subprocess");
-                Ok(())
-            }
-            Err(e) => {
-                error!(error = ?e, path = %daemon_path, "Failed to spawn daemon");
-                Err(e.into())
-            }
+        Err(e) => {
+            error!(error = ?e, path = ?daemon_path, "Failed to spawn daemon");
+            Err(e.into())
         }
     }
 }


### PR DESCRIPTION
The debug mode check was redundant as the daemon spawning logic is now consistent across both debug and release builds. This change improves maintainability by reducing code duplication and complexity.