### PR TITLE
fix(download): add zip_path to error log and enable deflate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5923,8 +5929,10 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "flate2",
  "indexmap 2.9.0",
  "memchr",
+ "zopfli",
 ]
 
 [[package]]
@@ -5936,6 +5944,20 @@ dependencies = [
  "log",
  "thiserror 2.0.12",
  "zip",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,9 @@ dwall = { version = "0", path = "../daemon" }
 
 reqwest = { version = "0", default-features = false }
 futures-util = { version = "0", default-features = false }
-zip-extract = { version = "0", default-features = false }
+zip-extract = { version = "0", default-features = false, features = [
+  "deflate",
+] }
 open = { version = "5", default-features = false }
 tokio = { workspace = true, features = ["macros", "process"] }
 dirs = { workspace = true }

--- a/src-tauri/src/download/extractor.rs
+++ b/src-tauri/src/download/extractor.rs
@@ -36,6 +36,7 @@ impl ThemeExtractor {
             error!(
                 theme_id = theme_id,
                 target_dir = %target_dir.display(),
+                zip_path = %zip_path.display(),
                 error = ?e,
                 "Failed to extract theme archive"
             );


### PR DESCRIPTION
The error log in the theme extraction process now includes the zip_path for better debugging. Additionally, the deflate feature is enabled in the zip-extract dependency to support compressed archives.

fix: https://github.com/dwall-rs/dwall/issues/319