### PR TITLE
style: reduce scrollbar width for better aesthetics

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -12,7 +12,7 @@
 }
 
 ::-webkit-scrollbar {
-  width: 8px;
+  width: 6px;
   height: 8px;
 }
 


### PR DESCRIPTION
The scrollbar width was reduced from 8px to 6px to improve the visual appeal and consistency with the design guidelines. This change does not affect functionality but enhances the overall user experience.