### PR TITLE
refactor: standardize layout and spacing with CSS variables

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,8 +1,6 @@
 .app {
+  --content-width: 500px;
   height: 100vh;
-  flex: 1;
-  padding: 0 0 10px 0;
-  justify-content: stretch;
 }
 
 .sidebar {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { Show } from "solid-js";
 
-import useDark from "alley-components/lib/hooks/useDark";
 
 import { LazyFlex } from "~/lazy";
 
@@ -11,6 +10,7 @@ import ThemeShowcase from "./components/ThemeShowcase";
 import Updater from "./components/Update";
 import Select from "./components/Select";
 
+import useDark from "~/hooks/useDark";
 import { useColorMode } from "./hooks/useColorMode";
 import { useAppInitialization } from "./hooks/useAppInitialization";
 
@@ -41,9 +41,9 @@ const App = () => {
 
   return (
     <>
-      <LazyFlex class="app" align="center" gap={24}>
+      <LazyFlex class="app" align="center" gap="xxl" justify="stretch">
         <LazyFlex
-          direction="vertical"
+          direction="column"
           align="center"
           justify="between"
           class="sidebar"
@@ -54,7 +54,7 @@ const App = () => {
         </LazyFlex>
 
         <Show when={!showSettings() && currentTheme()} fallback={<Settings />}>
-          <LazyFlex direction="vertical" gap={16} align="center">
+          <LazyFlex direction="column" gap="l" align="center">
             <Select
               options={monitors()}
               placeholder={translate("label-select-monitor")}

--- a/src/components/ImageCarousel/index.scss
+++ b/src/components/ImageCarousel/index.scss
@@ -1,5 +1,5 @@
 .fluent-carousel {
-  width: 480px;
+  width: var(--content-width);
   height: 480px;
   border-radius: 4px;
   display: flex;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -13,8 +13,25 @@ import "./index.scss";
 const Settings = () => {
   return (
     <>
-      <LazyFlex direction="vertical" style={{ width: "480px", height: "100%" }}>
-        <LazyFlex direction="vertical" gap={24} flex={15}>
+      <LazyFlex
+        direction="column"
+        style={{
+          width: "var(--content-width)",
+          "box-sizing": "border-box",
+          height: "100%",
+        }}
+        align="stretch"
+        justify="stretch"
+        paddingBottom="xs"
+        paddingTop="xs"
+      >
+        <LazyFlex
+          direction="column"
+          gap="xl"
+          style={{ flex: 15 }}
+          align="stretch"
+          justify="stretch"
+        >
           <AutoStart />
 
           <AutoDetectColorMode />

--- a/src/components/Settings/item.tsx
+++ b/src/components/Settings/item.tsx
@@ -51,7 +51,7 @@ const SettingsItem = (props: SettingsItemProps) => {
   const renderContent = children(() => {
     if (props.layout === "vertical") {
       return (
-        <LazyFlex direction="vertical" gap={8}>
+        <LazyFlex direction="column" gap="s" align="stretch">
           {renderLabel()}
           {props.children}
         </LazyFlex>
@@ -59,8 +59,8 @@ const SettingsItem = (props: SettingsItemProps) => {
     }
 
     const mainContent = (
-      <LazyFlex justify="between">
-        <LazySpace class="settings-item-content-wrapper" gap={2}>
+      <LazyFlex justify="between" align="center">
+        <LazySpace class="settings-item-content-wrapper" gap="xs">
           {renderLabel()}
           {props.help && (
             <LazyTooltip
@@ -84,7 +84,7 @@ const SettingsItem = (props: SettingsItemProps) => {
 
     if (props.layout === "horizontal" && props.extra) {
       return (
-        <LazyFlex direction="vertical" gap={8}>
+        <LazyFlex direction="column" gap="s" align="stretch">
           {mainContent}
           {props.extra}
         </LazyFlex>

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -63,7 +63,14 @@ export const ThemeMenu = (props: ThemeMenuProps) => {
   );
 
   return (
-    <LazyFlex direction="vertical" gap={8} class="thumbnails-container">
+    <LazyFlex
+      direction="column"
+      gap="s"
+      class="thumbnails-container"
+      grow={7}
+      shrink={1}
+      padding="10px 10px 10px 20px"
+    >
       {menu()}
     </LazyFlex>
   );

--- a/src/components/ThemeShowcase.tsx
+++ b/src/components/ThemeShowcase.tsx
@@ -10,8 +10,8 @@ const ThemeShowcase = () => {
 
   return (
     <LazyFlex
-      direction="vertical"
-      gap={16}
+      direction="column"
+      gap="l"
       justify="center"
       align="center"
       style={{ position: "relative" }}


### PR DESCRIPTION
This commit introduces a CSS variable `--content-width` to standardize the width of components across the application. Additionally, it refactors the layout and spacing in multiple components by replacing hardcoded values with consistent spacing tokens and updating `direction` properties to use `column` instead of `vertical` for better clarity and maintainability. The changes improve the overall consistency and scalability of the layout system.