### PR TITLE
feat(i18n): add update available message for notifications

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -50,6 +50,7 @@ pub(super) const MESSAGE_SWITCH_AUTO_LIGHT_DARK_MODE_FAILED: &str =
 pub(super) const MESSAGE_SWITCHING_TO_MANUAL_COORDINATE_CONFIG: &str =
     "message-switching-to-manual-coordinate-config";
 pub(super) const MESSAGE_THEMES_DIRECTORY_MOVED: &str = "message-themes-directory-moved";
+pub(super) const MESSAGE_UPDATE_AVAILABLE: &str = "message-update-available";
 pub(super) const MESSAGE_UPDATE_FAILED: &str = "message-update-failed";
 pub(super) const MESSAGE_VERSION_IS_THE_LATEST: &str = "message-version-is-the-latest";
 

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -189,6 +189,13 @@ impl TranslationMap for EnglishUSTranslations {
             },
         );
         translations.insert(
+            MESSAGE_UPDATE_AVAILABLE,
+            TranslationValue::Template {
+                template: "New version {{version}} detected, current version is {{currentVersion}}. Please click the upgrade button in the lower left corner to download and install.",
+                params: &["version", "currentVersion"],
+            },
+        );
+        translations.insert(
             MESSAGE_UPDATE_FAILED,
             TranslationValue::Template {
                 template: "Failed to update: \n{{error}}",

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -171,6 +171,14 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             },
         );
         translations.insert(
+            MESSAGE_UPDATE_AVAILABLE,
+            TranslationValue::Template {
+                template: "检测到新版本 {{version}}，当前版本 {{currentVersion}}
+      ，请点击左下角的升级按钮下载安装。",
+                params: &["version", "currentVersion"],
+            },
+        );
+        translations.insert(
             MESSAGE_UPDATE_FAILED,
             TranslationValue::Template {
                 template: "升级失败: \n{{error}}",

--- a/src/hooks/useAppInitialization.tsx
+++ b/src/hooks/useAppInitialization.tsx
@@ -1,12 +1,12 @@
 import { open } from "@tauri-apps/plugin-shell";
-import { onMount } from "solid-js";
+import { createEffect, onMount } from "solid-js";
 import {
   getAppliedThemeID,
   setTitlebarColorMode,
   showWindow,
 } from "~/commands";
 import { useToast } from "~/components/Toast";
-import { useMonitor, useTheme } from "~/contexts";
+import { useMonitor, useTheme, useUpdate } from "~/contexts";
 import { themes } from "~/themes";
 import { detectColorMode } from "~/utils/color";
 
@@ -23,6 +23,7 @@ export const useAppInitialization = (
   const { setMenuItemIndex, setAppliedThemeID } = useTheme();
   const { id: monitorID } = useMonitor();
   const toast = useToast();
+  const { update } = useUpdate();
 
   const openGithubRepository = async () => {
     await open("https://github.com/dwall-rs/dwall");
@@ -40,6 +41,23 @@ export const useAppInitialization = (
       </button>
     </span>
   );
+
+  const updateMessage = (
+    <span>
+      {translate("message-update-available", {
+        version: update()?.version ?? "",
+        currentVersion: update()?.currentVersion ?? "",
+      })}
+    </span>
+  );
+
+  createEffect(() => {
+    if (update()) {
+      toast.info(updateMessage, {
+        position: "top-right",
+      });
+    }
+  });
 
   onMount(async () => {
     await setTitlebarColorMode(detectColorMode());

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -37,6 +37,7 @@ type TranslationKey =
   | "message-switch-auto-light-dark-mode-failed"
   | "message-switching-to-manual-coordinate-config"
   | "message-themes-directory-moved"
+  | "message-update-available"
   | "message-update-failed"
   | "message-version-is-the-latest"
   | "placeholder-latitude"


### PR DESCRIPTION
Add a new translation key "message-update-available" to support notifying users when a new version is detected. This includes adding the key to the TypeScript definitions, Rust constants, and both English and Chinese translation files. Additionally, integrate the update message into the app initialization hook to display the notification when an update is available.