### PR TITLE
fix: Resolve dwall.exe termination issue in enterprise edition

### DIFF
--- a/src-tauri/windows/hooks.nsi
+++ b/src-tauri/windows/hooks.nsi
@@ -1,6 +1,40 @@
 !include "StrFunc.nsh"
-${StrStr}
-${UnStrStr}
+
+!macro TerminateDwallProcess
+  nsis_tauri_utils::FindProcess "dwall.exe"
+  Pop $R0
+  ${If} $R0 = 0
+    DetailPrint "Found dwall.exe process running, attempting to terminate..."
+    nsis_tauri_utils::KillProcess "dwall.exe"
+    Pop $R0
+
+    ${If} $R0 = 0
+      DetailPrint "Successfully terminated dwall.exe process"
+    ${Else}
+      DetailPrint "Failed to terminate process using nsis_tauri_utils, trying taskkill..."
+      # If above method failed, try using taskkill
+      nsExec::ExecToStack `taskkill /F /IM dwall.exe`
+      Pop $R1
+      Pop $R2
+      ${If} $R1 = 0
+        DetailPrint "Successfully terminated dwall.exe process using taskkill"
+      ${Else}
+        DetailPrint "Failed to terminate dwall.exe process: $R2"
+      ${EndIf}
+    ${EndIf}
+
+    # Add delay to ensure process is fully terminated
+    DetailPrint "Waiting for process to fully terminate..."
+    ${For} $R3 1 10
+        nsis_tauri_utils::FindProcess "dwall.exe"
+        Pop $R0
+        ${If} $R0 != 0
+            ${Break}
+        ${EndIf}
+        Sleep 200
+    ${Next}
+  ${EndIf}
+!macroend
 
 !macro NSIS_HOOK_PREINSTALL
   # NOTE: Clear incomplete thumbnails saved by old versions
@@ -9,35 +43,11 @@ ${UnStrStr}
   RMDir /r "$LOCALAPPDATA\com.thep0y.dwall"
   # ---- end ----
 
-  nsis_tauri_utils::FindProcess "dwall.exe"
-  Pop $R0
-  ${If} $R0 = 0
-    nsExec::ExecToStack `wmic process where "name='dwall.exe'" get ExecutablePath`
-    Pop $R1
-    Pop $R2
-    ${StrStr} $R3 "$R2" "$INSTDIR"
-    ${If} $R3 != ""
-      nsis_tauri_utils::KillProcess "dwall.exe"
-      Pop $R0
-      Sleep 1000
-    ${EndIf}
-  ${EndIf}
+  !insertmacro TerminateDwallProcess
 !macroend
 
 !macro NSIS_HOOK_PREUNINSTALL
-  nsis_tauri_utils::FindProcess "dwall.exe"
-  Pop $R0
-  ${If} $R0 = 0
-    nsExec::ExecToStack `wmic process where "name='dwall.exe'" get ExecutablePath`
-    Pop $R1
-    Pop $R2
-    ${UnStrStr} $R3 "$R2" "$INSTDIR"
-    ${If} $R3 != ""
-      nsis_tauri_utils::KillProcess "dwall.exe"
-      Pop $R0
-      Sleep 1000
-    ${EndIf}
-  ${EndIf}
+  !insertmacro TerminateDwallProcess
 
   DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "Dwall"
 !macroend


### PR DESCRIPTION
- Added a new macro `TerminateDwallProcess` to encapsulate the logic for terminating dwall.exe:
  - Attempts termination using `nsis_tauri_utils`, with fallback to `taskkill`.
  - Includes a delay mechanism to ensure full termination.
- Simplified `NSIS_HOOK_PREINSTALL` and `NSIS_HOOK_PREUNINSTALL` macros:
  - Replaced verbose logic with calls to `TerminateDwallProcess`.
  - Removed dependency on `wmic`.
- Enhanced logging for easier debugging.