### PR TITLE
refactor(logging): simplify logging setup and improve flexibility

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -205,7 +205,7 @@ async fn get_monitors() -> DwallSettingsResult<HashMap<String, dwall::monitor::M
 }
 
 fn main() -> DwallSettingsResult<()> {
-    setup_logging(&["dwall_settings".to_string(), "dwall".to_string()]);
+    setup_logging(&["dwall_settings", "dwall"]);
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
Refactor the `setup_logging` function to accept any string-like type using generics, reducing unnecessary allocations. Additionally, improve the `create_env_filter` function to use `EnvFilter::builder` for better clarity and consistency. These changes enhance code maintainability and flexibility without altering the logging behavior.