### PR TITLE
feat(i18n): add help text for github mirror template

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -9,6 +9,7 @@ pub(super) const BUTTON_STOP: &str = "button-stop";
 // ---------------- help ----------------
 pub(super) const HELP_AUTOMATICALLY_SWITCH_TO_DARK_MODE: &str =
     "help-automatically-switch-to-dark-mode";
+pub(super) const HELP_GITHUB_MIRROR_TEMPLATE: &str = "help-github-mirror-template";
 pub(super) const HELP_LAUNCH_AT_STARTUP: &str = "help-launch-at-startup";
 pub(super) const HELP_MANUALLY_SET_COORDINATES: &str = "help-manually-set-coordinates";
 pub(super) const HELP_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY: &str =

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -28,6 +28,10 @@ impl TranslationMap for EnglishUSTranslations {
             TranslationValue::Text("If you do not want to automatically switch between light and dark modes, please disable this option."),
         );
         translations.insert(
+            HELP_GITHUB_MIRROR_TEMPLATE,
+            TranslationValue::Text("Github mirror template is used to accelerate downloads. In some countries and regions, due to network restrictions, accessing Github may fail, resulting in download failures. You need to set up a Github mirror template to properly load thumbnails and download themes. Click this button to view available Github mirror templates."),
+        );
+        translations.insert(
             HELP_LAUNCH_AT_STARTUP,
             TranslationValue::Text(
                 "Autostart will only launch the background process, not the graphical program, and will not consume much memory.",

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -25,6 +25,10 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             TranslationValue::Text("如果你不希望自动切换明暗模式，请关闭此选项。"),
         );
         translations.insert(
+            HELP_GITHUB_MIRROR_TEMPLATE,
+            TranslationValue::Text("Github 镜像模板用于加速下载，部分国家和地区因为网络管制无法正常访问 Github，可能会下载失败，需要设置 Github 镜像模板以正常加载缩略图和下载主题。点击此按钮可以查看可用的 Github 镜像模板。"),
+        );
+        translations.insert(
             HELP_LAUNCH_AT_STARTUP,
             TranslationValue::Text(
                 "开机自启只会启动后台进程，不会启动本图形化程序，不会占用过多内存。",

--- a/src/components/Settings/GithubMirror.tsx
+++ b/src/components/Settings/GithubMirror.tsx
@@ -1,6 +1,8 @@
 import { createSignal } from "solid-js";
 import { AiFillSave } from "solid-icons/ai";
 
+import { open } from "@tauri-apps/plugin-shell";
+
 import { LazyButton, LazyInput } from "~/lazy";
 import SettingsItem from "./item";
 
@@ -33,6 +35,13 @@ const GithubMirror = () => {
     <SettingsItem
       layout="vertical"
       label={translate("label-github-mirror-template")}
+      help={{
+        content: translate("help-github-mirror-template"),
+        onClick: () =>
+          open(
+            "https://gh-proxy.com/gist.githubusercontent.com/thep0y/682ebeb2b8d4f6eea3841fe3f42c0e30/raw/2f5b641e77abe3cb8f74ee8f65ead95beb663444/markdown",
+          ),
+      }}
       vertical
     >
       <LazyInput

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -6,6 +6,7 @@ type TranslationKey =
   | "button-select-folder"
   | "button-stop"
   | "help-automatically-switch-to-dark-mode"
+  | "help-github-mirror-template"
   | "help-launch-at-startup"
   | "help-manually-set-coordinates"
   | "help-set-lock-screen-wallpaper-simultaneously"


### PR DESCRIPTION
Add translation keys and text for the Github mirror template help section in both English and Chinese locales. This provides users with guidance on using Github mirrors to accelerate downloads in regions with network restrictions.