### PR TITLE
feat(i18n): add translation for update failure message

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -14,6 +14,7 @@ pub(super) const HELP_LAUNCH_AT_STARTUP: &str = "help-launch-at-startup";
 pub(super) const HELP_MANUALLY_SET_COORDINATES: &str = "help-manually-set-coordinates";
 pub(super) const HELP_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY: &str =
     "help-set-lock-screen-wallpaper-simultaneously";
+pub(super) const HELP_UPDATE_FAILED: &str = "help-update-failed";
 
 // ---------------- labels ----------------
 pub(super) const LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES: &str =

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -45,6 +45,10 @@ impl TranslationMap for EnglishUSTranslations {
             HELP_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
             TranslationValue::Text("If you do not want to set the lock screen wallpaper simultaneously, please disable this option."),
         );
+        translations.insert(
+            HELP_UPDATE_FAILED,
+            TranslationValue::Text("Unable to complete the hot update. Please click the download button behind this message to manually download the new version: "),
+        );
 
         // labels
         translations.insert(

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -42,6 +42,10 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             HELP_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
             TranslationValue::Text("如果你不想同时设置锁屏壁纸，请关闭此选项。"),
         );
+        translations.insert(
+            HELP_UPDATE_FAILED,
+            TranslationValue::Text("无法完成热更新，请点击本消息后面的下载按钮手动下载新版本："),
+        );
 
         // labels
         translations.insert(

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -10,6 +10,7 @@ type TranslationKey =
   | "help-launch-at-startup"
   | "help-manually-set-coordinates"
   | "help-set-lock-screen-wallpaper-simultaneously"
+  | "help-update-failed"
   | "label-automatically-retrieve-coordinates"
   | "label-automatically-switch-to-dark-mode"
   | "label-check-interval"


### PR DESCRIPTION
Add a new translation key "help-update-failed" to provide a user-friendly message when an update fails. This includes updating the translation files for both English and Chinese, as well as integrating the new key into the UpdateDialog component to display the message with a download button for manual update.