### PR TITLE
refactor(position): encapsulate latitude and longitude fields

### DIFF
--- a/daemon/src/position.rs
+++ b/daemon/src/position.rs
@@ -5,8 +5,8 @@ use crate::{config::CoordinateSource, error::DwallResult};
 
 #[derive(Debug, Clone)]
 pub struct Position {
-    pub latitude: f64,
-    pub longitude: f64,
+    latitude: f64,
+    longitude: f64,
 }
 
 impl Position {
@@ -16,9 +16,17 @@ impl Position {
             longitude,
         }
     }
+
+    pub fn latitude(&self) -> f64 {
+        self.latitude
+    }
+
+    pub fn longitude(&self) -> f64 {
+        self.longitude
+    }
 }
 
-pub async fn get_geo_position() -> DwallResult<Position> {
+async fn get_geo_position() -> DwallResult<Position> {
     trace!("Initializing Geolocator...");
     let geolocator = Geolocator::new().map_err(|e| {
         error!(error = ?e, "Failed to initialize Geolocator");

--- a/daemon/src/theme/processor.rs
+++ b/daemon/src/theme/processor.rs
@@ -281,8 +281,8 @@ async fn process_theme_cycle(
     debug!(
         auto_detect_color_mode = config.auto_detect_color_mode(),
         image_format = ?config.image_format(),
-        latitude = geographic_position.latitude,
-        longitude = geographic_position.longitude,
+        latitude = geographic_position.latitude(),
+        longitude = geographic_position.longitude(),
         "Processing theme cycle with parameters"
     );
 
@@ -293,8 +293,8 @@ async fn process_theme_cycle(
 
     let current_time = OffsetDateTime::now_utc();
     let sun_position = SunPosition::new(
-        geographic_position.latitude,
-        geographic_position.longitude,
+        geographic_position.latitude(),
+        geographic_position.longitude(),
         current_time,
     );
 


### PR DESCRIPTION
Encapsulate the `latitude` and `longitude` fields in the `Position` struct by making them private and adding getter methods. This improves data encapsulation and ensures controlled access to these fields. Additionally, update the `get_geo_position` function to be private, as it is only used internally.