### PR TITLE
refactor(registry): consolidate registry operations into a dedicated module

### DIFF
--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -1,6 +1,4 @@
-use windows::Win32::Foundation::WIN32_ERROR;
-
-use crate::color_mode::ColorModeRegistryError;
+use crate::registry::RegistryError;
 
 /// Application result type, used for unified error handling
 pub type DwallResult<T> = std::result::Result<T, DwallError>;
@@ -30,9 +28,9 @@ pub enum DwallError {
     #[error("Configuration error: {0}")]
     Config(#[from] crate::config::ConfigError),
 
-    /// Color mode related error
-    #[error("Color mode setting failed: {0}")]
-    ColorMode(#[from] ColorModeRegistryError),
+    /// Registry related error
+    #[error("Registry error: {0}")]
+    Registry(#[from] RegistryError),
 
     /// Null character error
     #[error("String contains null character: {0}")]
@@ -57,30 +55,4 @@ pub enum DwallError {
     /// Timeout error
     #[error("Operation timed out: {0}")]
     Timeout(String),
-}
-
-/// Registry operation related errors
-///
-/// Contains all possible errors that may occur during interaction with the Windows registry
-#[derive(Debug, thiserror::Error)]
-pub enum RegistryError {
-    /// Failed to open registry key
-    #[error("Failed to open registry key: {0:?}")]
-    Open(WIN32_ERROR),
-
-    /// Failed to query registry value
-    #[error("Failed to query registry value: {0:?}")]
-    Query(WIN32_ERROR),
-
-    /// Failed to set registry value
-    #[error("Failed to set registry value: {0:?}")]
-    Set(WIN32_ERROR),
-
-    /// Failed to close registry handle
-    #[error("Failed to close registry handle: {0:?}")]
-    Close(WIN32_ERROR),
-
-    /// Failed to delete registry key
-    #[error("Failed to delete registry key: {0:?}")]
-    Delete(WIN32_ERROR),
 }

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -5,9 +5,10 @@ mod lazy;
 mod log;
 pub mod monitor;
 pub mod position;
+pub mod registry;
 mod solar;
 mod theme;
-mod utils;
+pub mod utils;
 
 #[macro_use]
 extern crate tracing;

--- a/daemon/src/registry.rs
+++ b/daemon/src/registry.rs
@@ -1,0 +1,221 @@
+use windows::{
+    core::{PCSTR, PCWSTR},
+    Win32::{
+        Foundation::{ERROR_FILE_NOT_FOUND, ERROR_SUCCESS, WIN32_ERROR},
+        System::Registry::{
+            RegCloseKey, RegDeleteValueW, RegOpenKeyExW, RegQueryValueExW, RegSetValueExA, HKEY,
+            HKEY_CURRENT_USER, REG_SAM_FLAGS, REG_VALUE_TYPE,
+        },
+    },
+};
+
+use crate::utils::string::WideStringExt;
+
+/// Registry operation related errors
+///
+/// Contains all possible errors that may occur during interaction with the Windows registry
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// Failed to open registry key
+    #[error("Failed to open registry key: {0:?}")]
+    Open(WIN32_ERROR),
+
+    /// Failed to query registry value
+    #[error("Failed to query registry value: {0:?}")]
+    Query(WIN32_ERROR),
+
+    /// Failed to set registry value
+    #[error("Failed to set registry value: {0:?}")]
+    Set(WIN32_ERROR),
+
+    /// Failed to close registry handle
+    #[error("Failed to close registry handle: {0:?}")]
+    Close(WIN32_ERROR),
+
+    /// Failed to delete registry key
+    #[error("Failed to delete registry key: {0:?}")]
+    Delete(WIN32_ERROR),
+}
+
+type RegistryResult<T> = Result<T, RegistryError>;
+
+/// RAII wrapper for Windows registry key handles
+/// Automatically closes the key handle when dropped
+pub struct RegistryKey {
+    hkey: HKEY,
+    path: String,
+}
+
+impl RegistryKey {
+    /// Open a registry key with specified access rights
+    pub fn open(path: &str, access: REG_SAM_FLAGS) -> RegistryResult<Self> {
+        debug!(path = path, "Attempting to open registry key");
+        let wide_path = Vec::from_str(path);
+        let mut hkey = HKEY::default();
+
+        let result = unsafe {
+            RegOpenKeyExW(
+                HKEY_CURRENT_USER,
+                PCWSTR(wide_path.as_ptr()),
+                None,
+                access,
+                &mut hkey,
+            )
+        };
+
+        match result {
+            ERROR_SUCCESS => {
+                debug!(path = path, "Successfully opened registry key");
+                Ok(Self {
+                    hkey,
+                    path: path.to_string(),
+                })
+            }
+            err => {
+                error!(
+                    path = path,
+                    error_code = err.0,
+                    "Failed to open registry key"
+                );
+                Err(RegistryError::Open(err).into())
+            }
+        }
+    }
+
+    /// Query registry value
+    ///
+    /// # Arguments
+    /// * `name` - Name of the value to query
+    /// * `data_type` - Optional parameter to receive the value type
+    /// * `data` - Optional parameter to receive the data
+    /// * `data_size` - Optional parameter to receive data size
+    ///
+    /// # Returns
+    /// - `Ok(())` - Query succeeded
+    /// - `Err(RegistryError)` - Query failed
+    ///
+    /// # Note
+    /// For string values, `data` should be a pointer to `Vec<u16>` instead of `Vec<u8>`,
+    /// as Windows will automatically convert strings to Unicode.
+    pub fn query(
+        &self,
+        name: &str,
+        data_type: Option<*mut REG_VALUE_TYPE>,
+        data: Option<*mut u8>,
+        data_size: Option<*mut u32>,
+    ) -> RegistryResult<()> {
+        trace!(
+            path = self.path,
+            name = name,
+            "Attempting to query registry value"
+        );
+
+        let value_name_wide = Vec::from_str(name);
+        let value_name = PCWSTR(value_name_wide.as_ptr());
+
+        let result =
+            unsafe { RegQueryValueExW(self.hkey, value_name, None, data_type, data, data_size) };
+
+        match result {
+            ERROR_SUCCESS => {
+                debug!(pointer = ?data, "Retrieved data from registry");
+                Ok(())
+            }
+            _ => {
+                error!(
+                    name = name,
+                    error_code = result.0,
+                    "Failed to query registry value",
+                );
+                Err(RegistryError::Query(result).into())
+            }
+        }
+    }
+
+    /// Set a registry value
+    ///
+    /// # Arguments
+    /// * `name` - The value name to set
+    /// * `value_type` - The registry value type (REG_DWORD, REG_SZ, etc)
+    /// * `data` - The data to set
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the value was set successfully
+    /// - `Err(DwallError)` - If registry operations fail
+    pub fn set(&self, name: &str, value_type: REG_VALUE_TYPE, data: &[u8]) -> RegistryResult<()> {
+        let value_name = PCSTR(name.as_ptr());
+
+        unsafe {
+            let result = RegSetValueExA(self.hkey, value_name, None, value_type, Some(data));
+
+            match result {
+                ERROR_SUCCESS => {
+                    debug!(name = name, "Successfully set registry value");
+                    Ok(())
+                }
+                err => {
+                    error!(
+                        name = name,
+                        error_code = err.0,
+                        "Failed to set registry value"
+                    );
+                    Err(RegistryError::Set(err).into())
+                }
+            }
+        }
+    }
+
+    /// Delete a registry value
+    ///
+    /// # Arguments
+    /// * `name` - The value name to delete
+    ///
+    /// # Returns
+    /// - `Ok(())` - If the value was deleted successfully
+    /// - `Err(DwallError)` - If registry operations fail
+    pub fn delete(&self, name: &str) -> RegistryResult<()> {
+        let value_name_wide = Vec::from_str(name);
+        let value_name = PCWSTR(value_name_wide.as_ptr());
+
+        unsafe {
+            let result = RegDeleteValueW(self.hkey, value_name);
+
+            match result {
+                ERROR_SUCCESS => {
+                    debug!(name = name, "Successfully deleted registry value");
+                    Ok(())
+                }
+                ERROR_FILE_NOT_FOUND => {
+                    warn!(name = name, "Registry value not found, skipping deletion");
+                    Ok(())
+                }
+                err => {
+                    error!(
+                        name = name,
+                        error_code = err.0,
+                        "Failed to delete registry value"
+                    );
+                    Err(RegistryError::Delete(err).into())
+                }
+            }
+        }
+    }
+}
+
+impl Drop for RegistryKey {
+    fn drop(&mut self) {
+        trace!(path = self.path, "Automatically closing registry key");
+        unsafe {
+            let err = RegCloseKey(self.hkey);
+            if err != ERROR_SUCCESS {
+                warn!(
+                    path = self.path,
+                    error_code = err.0,
+                    "Failed to close registry key on drop"
+                );
+            } else {
+                debug!(path = self.path, "Successfully closed registry key");
+            }
+        }
+    }
+}

--- a/src-tauri/src/auto_start.rs
+++ b/src-tauri/src/auto_start.rs
@@ -1,26 +1,16 @@
-use std::{ffi::CString, sync::LazyLock};
-
-use dwall::error::RegistryError;
-use windows::{
-    core::PCSTR,
-    Win32::{
-        Foundation::{ERROR_FILE_NOT_FOUND, ERROR_SUCCESS},
-        System::Registry::{
-            RegCloseKey, RegDeleteValueA, RegOpenKeyExA, RegQueryValueExA, RegSetValueExA, HKEY,
-            HKEY_CURRENT_USER, KEY_QUERY_VALUE, KEY_WRITE, REG_SAM_FLAGS, REG_SZ,
-        },
-    },
+use dwall::{
+    registry::{RegistryError, RegistryKey},
+    utils::string::WideStringRead,
+};
+use windows::Win32::{
+    Foundation::ERROR_FILE_NOT_FOUND,
+    System::Registry::{KEY_QUERY_VALUE, KEY_WRITE, REG_SZ},
 };
 
 use crate::{error::DwallSettingsResult, DAEMON_EXE_PATH};
 
 /// Manages Windows registry auto-start settings for an application
-pub struct AutoStartManager {
-    /// Name of the application in the registry
-    app_name: LazyLock<CString>,
-    /// Registry key path for auto-start entries
-    key_path: LazyLock<CString>,
-}
+pub struct AutoStartManager;
 
 impl AutoStartManager {
     /// Constant for the application name in the registry
@@ -28,78 +18,11 @@ impl AutoStartManager {
     /// Constant registry path for Windows auto-start entries
     const KEY_PATH: &'static str = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
 
-    /// Creates a new AutoStartManager instance
-    pub fn new() -> Self {
-        Self {
-            app_name: LazyLock::new(|| {
-                CString::new(Self::APP_NAME).expect("Failed to create CString for app name")
-            }),
-            key_path: LazyLock::new(|| {
-                CString::new(Self::KEY_PATH)
-                    .expect("Failed to create CString for registry key path")
-            }),
-        }
-    }
-
-    /// Opens the Windows registry key with specified access
-    ///
-    /// # Errors
-    /// Returns a `RegistryError` if the key cannot be opened
-    fn open_registry_key(&self, access: REG_SAM_FLAGS) -> Result<HKEY, RegistryError> {
-        let mut hkey = HKEY::default();
-
-        unsafe {
-            let reg_result = RegOpenKeyExA(
-                HKEY_CURRENT_USER,
-                PCSTR(self.key_path.as_ptr() as *const u8),
-                None,
-                access,
-                &mut hkey,
-            );
-
-            match reg_result {
-                ERROR_SUCCESS => {
-                    trace!(
-                        path = self.key_path.to_str().unwrap_or("Invalid path"),
-                        "Registry key opened successfully",
-                    );
-                    Ok(hkey)
-                }
-                _ => {
-                    error!(
-                        path = self.key_path.to_str().unwrap_or("Invalid path"), error_code = ?reg_result,
-                        "Failed to open registry key",
-                    );
-                    Err(RegistryError::Open(reg_result))
-                }
-            }
-        }
-    }
-
-    /// Safely closes an opened registry key
-    ///
-    /// # Errors
-    /// Returns a `DwallSettingsResult` if the key cannot be closed
-    fn close_registry_key(&self, hkey: HKEY) -> DwallSettingsResult<()> {
-        let close_result = unsafe { RegCloseKey(hkey) };
-
-        match close_result {
-            ERROR_SUCCESS => {
-                trace!("Registry key closed successfully");
-                Ok(())
-            }
-            _ => {
-                error!(error_code = close_result.0, "Failed to close registry key",);
-                Err(RegistryError::Close(close_result).into())
-            }
-        }
-    }
-
     /// Retrieves the executable path for auto-start
     ///
     /// # Errors
     /// Returns an error if the executable path cannot be retrieved
-    fn get_executable_path(&self) -> &'static str {
+    fn get_executable_path() -> &'static str {
         DAEMON_EXE_PATH.get().unwrap().to_str().unwrap()
     }
 
@@ -107,200 +30,128 @@ impl AutoStartManager {
     ///
     /// # Errors
     /// Returns a `DwallSettingsResult` if auto-start cannot be enabled
-    pub fn enable_auto_start(&self) -> DwallSettingsResult<()> {
+    pub fn enable_auto_start() -> DwallSettingsResult<()> {
         info!("Attempting to enable auto-start");
 
         // Safely get the executable path
-        let exe_path_str = self.get_executable_path();
+        let exe_path_str = Self::get_executable_path();
 
-        // Open registry key with write permissions
-        let hkey = self.open_registry_key(KEY_WRITE)?;
-
-        // Attempt to set the registry value
-        let set_result = unsafe {
-            RegSetValueExA(
-                hkey,
-                PCSTR(self.app_name.as_ptr() as *const u8),
-                None,
-                REG_SZ,
-                Some(exe_path_str.as_bytes()),
-            )
-        };
-
-        // Handle set result and ensure key is closed
-        match set_result {
-            ERROR_SUCCESS => {
-                self.close_registry_key(hkey)?;
-                info!("Auto-start enabled successfully");
-                Ok(())
-            }
-            _ => {
-                // Attempt to close key even if set failed
-                let _ = self.close_registry_key(hkey);
-
-                warn!(
+        let registry_key = RegistryKey::open(Self::KEY_PATH, KEY_WRITE)?;
+        registry_key
+            .set(Self::APP_NAME, REG_SZ, exe_path_str.as_bytes())
+            .map_err(|e| {
+                error!(
                     app_name = Self::APP_NAME,
                     path = exe_path_str,
-                    error_code = ?set_result,
+                    error = %e,
                     "Failed to set auto-start",
                 );
-                Err(RegistryError::Set(set_result).into())
-            }
-        }
+                e
+            })?;
+
+        info!("Auto-start enabled successfully");
+        Ok(())
     }
 
     /// Disables auto-start by removing the application from the registry
     ///
     /// # Errors
     /// Returns a `DwallSettingsResult` if auto-start cannot be disabled
-    pub fn disable_auto_start(&self) -> DwallSettingsResult<()> {
+    pub fn disable_auto_start() -> DwallSettingsResult<()> {
         info!("Attempting to disable auto-start");
 
-        // Open registry key with write permissions
-        let hkey = self.open_registry_key(KEY_WRITE)?;
+        let registry_key = RegistryKey::open(Self::KEY_PATH, KEY_WRITE)?;
+        registry_key.delete(Self::APP_NAME).map_err(|e| {
+            error!(
+                app_name = Self::APP_NAME,
+                error = %e,
+                "Failed to disable auto-start",
+            );
+            e
+        })?;
 
-        // Attempt to delete the registry value
-        let delete_result =
-            unsafe { RegDeleteValueA(hkey, PCSTR(self.app_name.as_ptr() as *const u8)) };
-
-        // Handle delete result and ensure key is closed
-        match delete_result {
-            ERROR_SUCCESS => {
-                self.close_registry_key(hkey)?;
-                info!("Auto-start disabled successfully");
-                Ok(())
-            }
-            ERROR_FILE_NOT_FOUND => {
-                // If the value doesn't exist, it's not an error
-                self.close_registry_key(hkey)?;
-                debug!("No existing auto-start entry found during disable");
-                Ok(())
-            }
-            _ => {
-                // Attempt to close key even if delete failed
-                let _ = self.close_registry_key(hkey);
-
-                warn!(
-                    app_name = Self::APP_NAME,
-                    error_code = delete_result.0,
-                    "Failed to disable auto-start",
-                );
-                Err(RegistryError::Delete(delete_result).into())
-            }
-        }
+        info!("Auto-start disabled successfully");
+        Ok(())
     }
 
     /// Checks if auto-start is currently enabled
     ///
     /// # Errors
     /// Returns a `DwallSettingsResult` if the auto-start status cannot be determined
-    pub fn check_auto_start(&self) -> DwallSettingsResult<bool> {
+    pub fn check_auto_start() -> DwallSettingsResult<bool> {
         trace!("Checking auto-start status");
 
-        // Open registry key with query permissions
-        let hkey = self.open_registry_key(KEY_QUERY_VALUE)?;
+        let registry_key = RegistryKey::open(Self::KEY_PATH, KEY_QUERY_VALUE)?;
 
         // Prepare variables for querying registry value
-        let mut value_type = REG_SZ;
-        let mut data: Vec<u8> = Vec::new();
+        let mut data_type = REG_SZ;
+        let mut data: Vec<u16> = Vec::new();
         let mut data_size = 0;
 
-        unsafe {
-            // First query to get required buffer size
-            let first_query_result = RegQueryValueExA(
-                hkey,
-                PCSTR(self.app_name.as_ptr() as *const u8),
-                Some(std::ptr::null_mut()),
-                Some(std::ptr::null_mut()),
-                None,
-                Some(&mut data_size),
-            );
+        // First query to get required buffer size
+        registry_key.query(Self::APP_NAME, None, None, Some(&mut data_size))?;
+        debug!(
+            app_name = Self::APP_NAME,
+            data_size = data_size,
+            "Buffer size for registry query",
+        );
 
-            match first_query_result {
-                ERROR_SUCCESS => {
-                    // Allocate buffer and perform second query
-                    data.resize(data_size as usize, 0);
-                    let second_query_result = RegQueryValueExA(
-                        hkey,
-                        PCSTR(self.app_name.as_ptr() as *const u8),
-                        Some(std::ptr::null_mut()),
-                        Some(&mut value_type),
-                        Some(data.as_mut_ptr()),
-                        Some(&mut data_size),
-                    );
+        // Allocate buffer and perform second query
+        data.resize(data_size as usize, 0);
+        match registry_key.query(
+            Self::APP_NAME,
+            Some(std::ptr::addr_of_mut!(data_type)),
+            Some(data.as_mut_ptr() as *mut u8),
+            Some(&mut data_size),
+        ) {
+            Ok(()) => {
+                // Get the current executable path
+                let exe_path_str = Self::get_executable_path();
 
-                    // Close the key first
-                    self.close_registry_key(hkey)?;
+                let command_str = data.to_string();
 
-                    // Process query results
-                    match second_query_result {
-                        ERROR_SUCCESS => {
-                            // Get the current executable path
-                            let exe_path_str = self.get_executable_path();
+                // Compare registry value with current executable path
+                let is_auto_start = command_str == exe_path_str;
 
-                            // Compare registry value with current executable path
-                            let command = data
-                                .iter()
-                                .take_while(|&&x| x != 0)
-                                .cloned()
-                                .collect::<Vec<u8>>();
-                            let command_str = String::from_utf8_lossy(&command).to_string();
+                info!(
+                    app_name = Self::APP_NAME,
+                    status = is_auto_start,
+                    command = %command_str,
+                    exe_path = %exe_path_str,
+                    "Auto-start status",
+                );
 
-                            let is_auto_start = command_str == exe_path_str;
-
-                            info!(
-                                app_name = Self::APP_NAME,
-                                status = is_auto_start,
-                                command = %command_str,
-                                "Auto-start status",
-                            );
-
-                            Ok(is_auto_start)
-                        }
-                        _ => {
-                            error!(
-                                app_name = Self::APP_NAME,
-                                error_code = second_query_result.0,
-                                "Failed to query registry value",
-                            );
-                            Err(RegistryError::Query(second_query_result).into())
-                        }
-                    }
-                }
-                ERROR_FILE_NOT_FOUND => {
-                    // Close the key first
-                    self.close_registry_key(hkey)?;
-
-                    debug!("No auto-start entry found for {}", Self::APP_NAME);
-                    Ok(false)
-                }
-                _ => {
-                    // Close the key first
-                    self.close_registry_key(hkey)?;
-
-                    error!(
-                        app_name = Self::APP_NAME,
-                        error_code = first_query_result.0,
-                        "Unexpected error querying registry",
-                    );
-                    Err(RegistryError::Query(first_query_result).into())
-                }
+                Ok(is_auto_start)
             }
+            Err(RegistryError::Query(err)) => {
+                if err == ERROR_FILE_NOT_FOUND {
+                    debug!(app_name = Self::APP_NAME, "No auto-start entry found");
+                    return Ok(false);
+                }
+
+                error!(
+                    app_name = Self::APP_NAME,
+                    error_code = err.0,
+                    "Unexpected error querying registry",
+                );
+                Err(RegistryError::Query(err).into())
+            }
+            _ => unreachable!(),
         }
     }
 }
 
 #[tauri::command]
-pub fn enable_auto_start(manager: tauri::State<AutoStartManager>) -> DwallSettingsResult<()> {
-    manager.enable_auto_start()
+pub fn enable_auto_start() -> DwallSettingsResult<()> {
+    AutoStartManager::enable_auto_start()
 }
 
 #[tauri::command]
-pub fn disable_auto_start(manager: tauri::State<AutoStartManager>) -> DwallSettingsResult<()> {
-    manager.disable_auto_start()
+pub fn disable_auto_start() -> DwallSettingsResult<()> {
+    AutoStartManager::disable_auto_start()
 }
 
 #[tauri::command]
-pub fn check_auto_start(manager: tauri::State<AutoStartManager>) -> DwallSettingsResult<bool> {
-    manager.check_auto_start()
+pub fn check_auto_start() -> DwallSettingsResult<bool> {
+    AutoStartManager::check_auto_start()
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,4 +1,4 @@
-use dwall::error::RegistryError;
+use dwall::registry::RegistryError;
 use serde::{Serialize, Serializer};
 
 use crate::download::DownloadError;

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -3,9 +3,8 @@ use std::{env, path::PathBuf, str::FromStr};
 use tauri::Manager;
 
 use crate::{
-    auto_start::AutoStartManager, download::ThemeDownloader, error::DwallSettingsError,
-    process_manager::find_daemon_process, read_config_file, theme::spawn_apply_daemon,
-    window::create_main_window, DAEMON_EXE_PATH,
+    download::ThemeDownloader, error::DwallSettingsError, process_manager::find_daemon_process,
+    read_config_file, theme::spawn_apply_daemon, window::create_main_window, DAEMON_EXE_PATH,
 };
 
 pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -38,8 +37,6 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     info!(path = %daemon_exe_path.display(), "Found daemon exe");
     DAEMON_EXE_PATH.set(daemon_exe_path)?;
 
-    let auto_start_manager = AutoStartManager::new();
-    app.manage(auto_start_manager);
     let theme_downloader = ThemeDownloader::new();
     app.manage(theme_downloader);
 


### PR DESCRIPTION
Move registry-related functionality from `color_mode.rs` and `auto_start.rs` into a new `registry.rs` module. This improves code organization and reusability by centralizing registry operations. The changes include:
- Extracting registry key handling into a reusable `RegistryKey` struct
- Simplifying `ColorModeManager` and `AutoStartManager` by leveraging the new `RegistryKey` abstraction
- Removing redundant registry error handling code