### PR TITLE
refactor(monitor): simplify device friendly name retrieval

### DIFF
--- a/daemon/src/monitor/error.rs
+++ b/daemon/src/monitor/error.rs
@@ -32,4 +32,8 @@ pub enum MonitorError {
     /// Failed to query display configuration
     #[error("Failed to query display configuration: {0:?}")]
     QueryDisplayConfig(WIN32_ERROR),
+
+    /// Failed to get device registry property
+    #[error("Failed to get device registry property: {0:?}")]
+    GetDeviceRegistryProperty(#[source] WindowsError),
 }


### PR DESCRIPTION
Refactor the `get_device_friendly_name` function to use a fixed buffer size and leverage the `WideStringRead` utility for string conversion. This reduces complexity and improves maintainability by removing redundant buffer size calculations and error handling logic.