### PR TITLE
feat(config): add support for global theme setting

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -91,13 +91,19 @@ async fn get_applied_theme_id(monitor_id: &str) -> DwallSettingsResult<Option<St
         Ok(config) => {
             let monitor_themes = config.monitor_specific_wallpapers();
             let theme_id = if monitor_id == "all" {
-                let mut iter = monitor_themes.values();
-                let first_value = iter.next();
-                let theme_id = if iter.all(|value| Some(value) == first_value) {
-                    first_value
-                } else {
-                    None
+                let theme_id = match monitor_themes {
+                    dwall::config::MonitorSpecificWallpapers::All(theme_id) => Some(theme_id),
+                    dwall::config::MonitorSpecificWallpapers::Specific(themes_map) => {
+                        let mut iter = themes_map.values();
+                        let first_value = iter.next();
+                        if iter.all(|value| Some(value) == first_value) {
+                            first_value
+                        } else {
+                            None
+                        }
+                    }
                 };
+
                 info!(theme_id = ?theme_id, "Retrieved all theme ID");
                 theme_id
             } else {

--- a/src/components/ThemeActions.tsx
+++ b/src/components/ThemeActions.tsx
@@ -17,7 +17,7 @@ export interface ThemeActionsProps {
 
 export const ThemeActions = () => {
   const theme = useTheme();
-  const { id: monitorID, list: monitors } = useMonitor();
+  const { id: monitorID } = useMonitor();
 
   const { translate } = useTranslations();
   const { handleTaskClosure } = useTask();
@@ -26,7 +26,7 @@ export const ThemeActions = () => {
 
   const onApply = async () => {
     setSpinning(true);
-    await theme.handleThemeApplication(monitorID, monitors);
+    await theme.handleThemeApplication(monitorID);
     setSpinning(false);
   };
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -21,10 +21,7 @@ interface ThemeContext {
   setMenuItemIndex: Setter<number | undefined>;
   themeExists: Accessor<boolean>;
   handleThemeSelection: (index: number) => void;
-  handleThemeApplication: (
-    monitorID: Accessor<string>,
-    monitors: Accessor<MonitorItem[]>,
-  ) => Promise<void>;
+  handleThemeApplication: (monitorID: Accessor<string>) => Promise<void>;
 }
 
 const ThemeContext = createContext<ThemeContext>();
@@ -58,7 +55,7 @@ export const ThemeProvider = (props: ParentProps) => {
       setThemeExists(true);
     } catch (e) {
       setThemeExists(false);
-      console.error("Failed to check theme existence:", e);
+      console.error(`Failed to check theme existence: index=${idx} error=${e}`);
     }
   };
 

--- a/src/hooks/monitor/useMonitorSelection.tsx
+++ b/src/hooks/monitor/useMonitorSelection.tsx
@@ -31,13 +31,30 @@ export const useMonitorSelection = () => {
 
   // Get monitor-specific theme configuration
   const monitorSpecificThemes = createMemo(() => {
-    return Object.entries(config()?.monitor_specific_wallpapers ?? {}).sort(
-      (a, b) => a[0].toLocaleLowerCase().localeCompare(b[0]),
+    const monitor_specific_wallpapers = config()?.monitor_specific_wallpapers;
+    if (!monitor_specific_wallpapers) return [];
+
+    if (typeof monitor_specific_wallpapers === "string") {
+      const monitorIDs = Object.keys(monitorInfoObject() ?? {}).sort();
+      return monitorIDs.map(
+        (id) => [id, monitor_specific_wallpapers] as [string, string],
+      );
+    }
+
+    return Object.entries(monitor_specific_wallpapers).sort((a, b) =>
+      a[0].toLocaleLowerCase().localeCompare(b[0]),
     );
   });
 
   // Check if all monitors are using the same theme
   const monitorSpecificThemesIsSame = createMemo(() => {
+    const monitor_specific_wallpapers = config()?.monitor_specific_wallpapers;
+    if (
+      !monitor_specific_wallpapers ||
+      typeof monitor_specific_wallpapers === "string"
+    )
+      return true;
+
     const themes = monitorSpecificThemes();
     const monitorIDs = Object.keys(monitorInfoObject() ?? {}).sort();
 

--- a/src/hooks/monitor/useMonitorThemeSync.tsx
+++ b/src/hooks/monitor/useMonitorThemeSync.tsx
@@ -21,10 +21,7 @@ export const useMonitorThemeSync = (
 
   // Monitor display selection changes, update theme state
   createEffect(async () => {
-    const id =
-      monitorID() === "all"
-        ? Object.values(config()?.monitor_specific_wallpapers ?? {})[0]
-        : config()?.monitor_specific_wallpapers[monitorID()!];
+    const id = getThemeID(monitorID(), config()?.monitor_specific_wallpapers);
 
     if (!id || (!monitorSpecificThemesIsSame() && monitorID() === "all")) {
       setAppliedThemeID(undefined);
@@ -35,4 +32,14 @@ export const useMonitorThemeSync = (
       setMenuItemIndex(index);
     }
   });
+};
+
+const getThemeID = (
+  monitorID: string,
+  monitor_specific_wallpapers?: Config["monitor_specific_wallpapers"],
+) => {
+  if (typeof monitor_specific_wallpapers === "string")
+    return monitor_specific_wallpapers;
+
+  return monitor_specific_wallpapers?.[monitorID];
 };

--- a/src/hooks/theme/useThemeApplication.tsx
+++ b/src/hooks/theme/useThemeApplication.tsx
@@ -21,10 +21,7 @@ export const useThemeApplication = (
   const { translateErrorMessage } = useTranslations();
 
   // Handle theme application
-  const handleThemeApplication = async (
-    monitorID: Accessor<string>,
-    monitors: Accessor<MonitorItem[]>,
-  ) => {
+  const handleThemeApplication = async (monitorID: Accessor<string>) => {
     const theme = currentTheme();
     if (!theme || !config()) return;
 
@@ -42,19 +39,22 @@ export const useThemeApplication = (
     }
 
     // Update monitor-specific wallpaper configuration
-    const monitorSpecificWallpapers: Record<string, string> = {
-      ...currentConfig.monitor_specific_wallpapers,
-    };
+    let monitorSpecificWallpapers: Record<string, string> | string;
+    // const monitorSpecificWallpapers: Record<string, string> = {
+    //   ...currentConfig.monitor_specific_wallpapers,
+    // };
 
-    if (monitorID() !== "all") {
-      // Set theme for specific monitor
-      monitorSpecificWallpapers[monitorID()!] = theme.id;
-    } else {
+    if (monitorID() === "all") {
       // Set the same theme for all monitors
-      for (const { value } of monitors()) {
-        if (value === "all") continue;
-        monitorSpecificWallpapers[value] = theme.id;
-      }
+      monitorSpecificWallpapers = theme.id;
+    } else {
+      // Set theme for specific monitor
+      monitorSpecificWallpapers =
+        typeof currentConfig.monitor_specific_wallpapers === "string"
+          ? {}
+          : { ...currentConfig.monitor_specific_wallpapers };
+
+      monitorSpecificWallpapers[monitorID()!] = theme.id;
     }
 
     currentConfig.monitor_specific_wallpapers = monitorSpecificWallpapers;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -7,7 +7,7 @@ interface Config {
   coordinate_source: CoordinateSource;
   auto_detect_color_mode: boolean;
   lock_screen_wallpaper_enabled: boolean;
-  monitor_specific_wallpapers: Record<string, string>;
+  monitor_specific_wallpapers: string | Record<string, string>;
 }
 
 interface CoordinateSourceAutomatic {


### PR DESCRIPTION
- Introduce `MonitorSpecificWallpapers` enum to support both global and per-monitor themes
- Update `Config` struct to use the new `MonitorSpecificWallpapers` type
- Modify `get_applied_theme_id` function to handle both global and per-monitor themes
- Update `ThemeContext` and related components to support the new theme setting
- Refactor `useMonitorThemeSync` and `useThemeApplication` hooks to handle the new theme setting