### PR TITLE
refactor: apply clippy fixes and improve code quality

### DIFF
--- a/daemon/src/log.rs
+++ b/daemon/src/log.rs
@@ -21,8 +21,8 @@ fn get_log_level() -> Level {
     env::var("DWALL_LOG")
         .ok()
         .as_deref()
-        .or_else(|| option_env!("DWALL_LOG"))
-        .and_then(|level| Level::from_str(&level).ok())
+        .or(option_env!("DWALL_LOG"))
+        .and_then(|level| Level::from_str(level).ok())
         .unwrap_or_else(default_log_level)
 }
 

--- a/daemon/src/monitor/device_interface.rs
+++ b/daemon/src/monitor/device_interface.rs
@@ -230,5 +230,5 @@ fn get_device_friendly_name(
     let friendly_name = u16_data.to_string();
 
     debug!(friendly_name, "Got device friendly name");
-    return Ok(friendly_name);
+    Ok(friendly_name)
 }

--- a/daemon/src/monitor/mod.rs
+++ b/daemon/src/monitor/mod.rs
@@ -100,7 +100,7 @@ impl MonitorManager {
         })?;
 
         self.wallpaper_manager
-            .set_wallpaper(monitor, &wallpaper_path)
+            .set_wallpaper(monitor, wallpaper_path)
             .await
             .map_err(|e| {
                 error!(

--- a/daemon/src/position/position_manager.rs
+++ b/daemon/src/position/position_manager.rs
@@ -24,7 +24,7 @@ async fn get_geo_position() -> DwallResult<Position> {
     check_location_permission().await?;
 
     // Initialize geolocator
-    let geolocator = handle_windows_error("Initializing Geolocator", || Geolocator::new()).await?;
+    let geolocator = handle_windows_error("Initializing Geolocator", Geolocator::new).await?;
 
     // Set accuracy to high
     handle_windows_error("Setting desired accuracy to High", || {

--- a/daemon/src/registry.rs
+++ b/daemon/src/registry.rs
@@ -77,7 +77,7 @@ impl RegistryKey {
                     error_code = err.0,
                     "Failed to open registry key"
                 );
-                Err(RegistryError::Open(err).into())
+                Err(RegistryError::Open(err))
             }
         }
     }
@@ -127,7 +127,7 @@ impl RegistryKey {
                     error_code = result.0,
                     "Failed to query registry value",
                 );
-                Err(RegistryError::Query(result).into())
+                Err(RegistryError::Query(result))
             }
         }
     }
@@ -159,7 +159,7 @@ impl RegistryKey {
                         error_code = err.0,
                         "Failed to set registry value"
                     );
-                    Err(RegistryError::Set(err).into())
+                    Err(RegistryError::Set(err))
                 }
             }
         }
@@ -195,7 +195,7 @@ impl RegistryKey {
                         error_code = err.0,
                         "Failed to delete registry value"
                     );
-                    Err(RegistryError::Delete(err).into())
+                    Err(RegistryError::Delete(err))
                 }
             }
         }

--- a/src-tauri/src/cache/cleanup_service.rs
+++ b/src-tauri/src/cache/cleanup_service.rs
@@ -66,7 +66,7 @@ impl CleanupService {
                             if let Ok(modified) = metadata.modified() {
                                 if now
                                     .duration_since(modified)
-                                    .map_or(false, |age| age > expiry_duration)
+                                    .is_ok_and(|age| age > expiry_duration)
                                 {
                                     // File expired, delete it
                                     let file_size = metadata.len();

--- a/src-tauri/src/process_manager.rs
+++ b/src-tauri/src/process_manager.rs
@@ -172,7 +172,7 @@ pub fn find_daemon_process() -> DwallSettingsResult<Option<u32>> {
         ..Default::default()
     };
 
-    let result = unsafe {
+    unsafe {
         // Start iterating through processes
         if Process32First(snapshot.as_raw(), &mut process_entry).is_ok() {
             find_matching_process(
@@ -185,9 +185,7 @@ pub fn find_daemon_process() -> DwallSettingsResult<Option<u32>> {
             error!("Failed to get first process in snapshot");
             Ok(None)
         }
-    };
-
-    result
+    }
 }
 
 /// Helper function to find matching process by iterating through processes


### PR DESCRIPTION
- Fix clippy warnings and suggestions
- Improve error handling in registry operations
- Refactor log level retrieval in log module
- Simplify device friendly name retrieval in monitor module
- Use map_err instead of and_then for error handling in position manager
- Use is_ok_and instead of map_or for cache cleanup service
- Refactor HTTP download service for better code organization and readability
- Simplify find_daemon_process function in process manager