### PR TITLE
build: remove outdated schema reference

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dwall Settings",
   "version": "../package.json",
   "identifier": "com.thep0y.dwall",

--- a/src-tauri/tauri.debug.conf.json
+++ b/src-tauri/tauri.debug.conf.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
   "build": {
     "beforeBuildCommand": "bun run build:vite && bun run build:daemon-debug"
   }


### PR DESCRIPTION
- Remove "$schema" field from tauri.conf.json and tauri.debug.conf.json
- This field was likely unused or outdated in the configuration files