### PR TITLE
refactor(monitor): rename Monitor to DisplayMonitor and improve caching

### DIFF
--- a/daemon/src/monitor/mod.rs
+++ b/daemon/src/monitor/mod.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use crate::error::DwallResult;
 
 // Re-export Monitor struct for public use
-pub use monitor_info::{Monitor, MonitorInfoProvider};
+pub use monitor_info::{DisplayMonitor, DisplayMonitorProvider};
 pub(crate) use wallpaper_manager::{MonitorWallpaperManager, MonitorWallpaperManagerError};
 
 /// For backward compatibility with existing code
@@ -19,7 +19,7 @@ pub struct MonitorManager {
     /// Wallpaper manager instance
     wallpaper_manager: MonitorWallpaperManager,
     /// Monitor information provider
-    monitor_provider: MonitorInfoProvider,
+    monitor_provider: DisplayMonitorProvider,
 }
 
 impl MonitorManager {
@@ -27,7 +27,7 @@ impl MonitorManager {
     pub fn new() -> DwallResult<Self> {
         Ok(Self {
             wallpaper_manager: MonitorWallpaperManager::new()?,
-            monitor_provider: MonitorInfoProvider::new(),
+            monitor_provider: DisplayMonitorProvider::new(),
         })
     }
 
@@ -116,17 +116,17 @@ impl MonitorManager {
     }
 
     /// Gets all available monitors with caching
-    pub async fn get_monitors(&self) -> DwallResult<HashMap<String, Monitor>> {
+    pub async fn get_monitors(&self) -> DwallResult<HashMap<String, DisplayMonitor>> {
         self.monitor_provider.get_monitors().await
     }
 
     /// Forces a refresh of monitor information
-    pub async fn refresh_monitors(&self) -> DwallResult<HashMap<String, Monitor>> {
+    pub async fn refresh_monitors(&self) -> DwallResult<HashMap<String, DisplayMonitor>> {
         self.monitor_provider.refresh_monitors().await
     }
 
     /// Detects if monitor configuration has changed
     pub async fn has_monitor_config_changed(&self) -> DwallResult<bool> {
-        self.monitor_provider.has_monitor_config_changed().await
+        self.monitor_provider.has_configuration_changed().await
     }
 }

--- a/daemon/src/monitor/monitor_info.rs
+++ b/daemon/src/monitor/monitor_info.rs
@@ -13,78 +13,93 @@ use crate::{error::DwallResult, utils::string::WideStringRead};
 use super::{device_interface, display_config};
 
 /// Cache expiration time in seconds
-const MONITOR_CACHE_EXPIRY: u64 = 30;
+const CACHE_EXPIRY_SECONDS: u64 = 30;
 
 /// Unified monitor information structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Monitor {
-    /// Unique identifier for the monitor (device path)
-    pub id: String,
-    /// Full device path
-    pub device_path: String,
+pub struct DisplayMonitor {
+    // /// Unique identifier for the monitor (device path)
+    // pub id: String,
+    /// Unique device path identifier
+    device_path: String,
     /// User-friendly display name
-    pub friendly_name: String,
-    /// Monitor index (position in the display configuration)
-    pub index: Option<u32>,
+    friendly_name: String,
+    /// Monitor position index in display configuration
+    position_index: Option<u32>,
+}
+
+impl DisplayMonitor {
+    fn new(device_path: String, friendly_name: String, position_index: Option<u32>) -> Self {
+        Self {
+            device_path,
+            friendly_name,
+            position_index,
+        }
+    }
+
+    pub(super) fn device_path(&self) -> &str {
+        &self.device_path
+    }
 }
 
 /// Cache structure for monitor information
-struct MonitorCache {
-    /// Cached monitor information
-    monitors: HashMap<String, Monitor>,
-    /// Last update timestamp
-    last_update: Instant,
+struct MonitorInfoCache {
+    /// Cached monitor data (key: device_path)
+    data: HashMap<String, DisplayMonitor>,
+    /// Last cache update timestamp
+    updated_at: Instant,
 }
 
-impl MonitorCache {
+impl MonitorInfoCache {
     /// Creates a new empty cache
     fn new() -> Self {
         Self {
-            monitors: HashMap::new(),
-            last_update: Instant::now(),
+            data: HashMap::new(),
+            updated_at: Instant::now(),
         }
     }
 
-    /// Checks if the cache is expired
-    fn is_expired(&self) -> bool {
-        self.last_update.elapsed() > Duration::from_secs(MONITOR_CACHE_EXPIRY)
+    /// Checks if the cache is expired or empty
+    fn is_valid(&self) -> bool {
+        !self.data.is_empty()
+            && self.updated_at.elapsed() <= Duration::from_secs(CACHE_EXPIRY_SECONDS)
     }
 
     /// Updates the cache with new monitor information
-    fn update(&mut self, monitors: HashMap<String, Monitor>) {
-        self.monitors = monitors;
-        self.last_update = Instant::now();
+    fn update(&mut self, monitors: HashMap<String, DisplayMonitor>) {
+        self.data = monitors;
+        self.updated_at = Instant::now();
     }
 }
 
-/// Provider for monitor information with caching
-pub struct MonitorInfoProvider {
-    /// Cache for monitor information
-    cache: Arc<RwLock<MonitorCache>>,
+/// Provider for display monitor information with caching
+pub struct DisplayMonitorProvider {
+    /// Thread-safe cached monitor information
+    cache: Arc<RwLock<MonitorInfoCache>>,
 }
 
-impl Default for MonitorInfoProvider {
+impl Default for DisplayMonitorProvider {
     fn default() -> Self {
         Self {
-            cache: Arc::new(RwLock::new(MonitorCache::new())),
+            cache: Arc::new(RwLock::new(MonitorInfoCache::new())),
         }
     }
 }
 
-impl MonitorInfoProvider {
+impl DisplayMonitorProvider {
     /// Creates a new MonitorInfoProvider instance
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Gets all available monitors with caching
-    pub async fn get_monitors(&self) -> DwallResult<HashMap<String, Monitor>> {
+    pub async fn get_monitors(&self) -> DwallResult<HashMap<String, DisplayMonitor>> {
         // Try to read from cache first
         {
             let cache = self.cache.read().await;
-            if !cache.is_expired() && !cache.monitors.is_empty() {
+            if cache.is_valid() {
                 debug!("Using cached monitor information");
-                return Ok(cache.monitors.clone());
+                return Ok(cache.data.clone());
             }
         }
 
@@ -93,9 +108,9 @@ impl MonitorInfoProvider {
     }
 
     /// Forces a refresh of monitor information
-    pub async fn refresh_monitors(&self) -> DwallResult<HashMap<String, Monitor>> {
+    pub async fn refresh_monitors(&self) -> DwallResult<HashMap<String, DisplayMonitor>> {
         debug!("Refreshing monitor information");
-        let monitors = query_monitor_info()?;
+        let monitors = fetch_system_monitors()?;
 
         // Update cache
         {
@@ -107,21 +122,20 @@ impl MonitorInfoProvider {
     }
 
     /// Detects if monitor configuration has changed
-    pub async fn has_monitor_config_changed(&self) -> DwallResult<bool> {
-        let current_monitors = query_monitor_info()?;
+    pub async fn has_configuration_changed(&self) -> DwallResult<bool> {
+        let current_monitors = fetch_system_monitors()?;
 
         // Compare with cached monitors
         let cache = self.cache.read().await;
-        let cached_monitors = &cache.monitors;
 
-        // Check if number of monitors changed
-        if current_monitors.len() != cached_monitors.len() {
+        // Quick check: different monitor count means configuration changed
+        if current_monitors.len() != cache.data.len() {
             return Ok(true);
         }
 
-        // Check if any monitor IDs changed
-        for id in current_monitors.keys() {
-            if !cached_monitors.contains_key(id) {
+        // Check if any monitor device paths are different
+        for device_path in current_monitors.keys() {
+            if !cache.data.contains_key(device_path) {
                 return Ok(true);
             }
         }
@@ -131,8 +145,8 @@ impl MonitorInfoProvider {
 }
 
 /// Queries monitor information from the system
-pub(crate) fn query_monitor_info() -> DwallResult<HashMap<String, Monitor>> {
-    debug!("Querying monitor information from system");
+pub(crate) fn fetch_system_monitors() -> DwallResult<HashMap<String, DisplayMonitor>> {
+    debug!("Fetching monitor information from system");
     let mut monitors = HashMap::new();
 
     for (index, display_path) in display_config::query_display_paths()?
@@ -143,33 +157,31 @@ pub(crate) fn query_monitor_info() -> DwallResult<HashMap<String, Monitor>> {
             display_config::query_target_name(display_path.adapter_id, display_path.target_id)?;
         let device_path = target_info.monitorDevicePath.to_string();
 
-        // Try to get friendly name, use device path as fallback
+        // Try to get friendly name, use fallback if unavailable
         let friendly_name = match device_interface::query_device_friendly_name(
             &device_path,
             &GUID_DEVINTERFACE_MONITOR,
         ) {
-            Ok(name) => {
-                debug!(friendly_name = name, "Successfully retrieved friendly name");
-                name
-            }
+            Ok(name) => name,
             Err(e) => {
                 warn!(error = ?e, "Failed to get friendly name, using fallback");
-                // Use a fallback name based on the device path
-                format!("Display {}", index + 1)
+                format!("Display {}", index + 1) // Fallback name
             }
         };
 
         monitors.insert(
             device_path.clone(),
-            Monitor {
-                id: device_path.clone(),
+            DisplayMonitor::new(
+                // id: device_path.clone(),
                 device_path,
                 friendly_name,
-                index: Some(index as u32),
-            },
+                Some(index as u32),
+            ),
         );
     }
 
-    info!(monitors = ?monitors, "Found all active monitors");
+    let monitor_count = monitors.len();
+    info!("Found {} active monitor(s)", monitor_count);
+
     Ok(monitors)
 }

--- a/daemon/src/monitor/wallpaper_manager.rs
+++ b/daemon/src/monitor/wallpaper_manager.rs
@@ -8,7 +8,7 @@ use windows::{
     },
 };
 
-use super::monitor_info::Monitor;
+use super::monitor_info::DisplayMonitor;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MonitorWallpaperManagerError {
@@ -101,16 +101,16 @@ impl MonitorWallpaperManager {
     /// Sets wallpaper for a specific monitor
     pub async fn set_wallpaper(
         &self,
-        monitor: &Monitor,
+        monitor: &DisplayMonitor,
         wallpaper_path: &Path,
     ) -> MonitorWallpaperManagerResult<()> {
         // Convert wallpaper path to HSTRING
         let wallpaper_path = HSTRING::from(wallpaper_path);
-        let device_path = HSTRING::from(&monitor.device_path);
+        let device_path = HSTRING::from(monitor.device_path());
 
         if self.is_wallpaper_already_set(&device_path, &wallpaper_path)? {
             info!(
-                monitor_id = monitor.id,
+                monitor_id = monitor.device_path(),
                 wallpaper_path = %wallpaper_path,
                 "Wallpaper already set for monitor, skipping"
             );
@@ -124,7 +124,7 @@ impl MonitorWallpaperManager {
                 .map_err(|e| {
                     error!(
                         error = ?e,
-                        monitor_id = monitor.id,
+                        monitor_id = monitor.device_path(),
                         wallpaper_path = %wallpaper_path,
                         "Failed to set wallpaper for monitor"
                     );

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -120,7 +120,7 @@ async fn set_titlebar_color_mode(
 }
 
 #[tauri::command]
-async fn get_monitors() -> DwallSettingsResult<HashMap<String, dwall::monitor::Monitor>> {
+async fn get_monitors() -> DwallSettingsResult<HashMap<String, dwall::monitor::DisplayMonitor>> {
     let monitors = monitor::get_monitors().await?;
 
     Ok(monitors)

--- a/src-tauri/src/monitor.rs
+++ b/src-tauri/src/monitor.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use dwall::{
-    monitor::{Monitor, MonitorInfoProvider},
+    monitor::{DisplayMonitor, DisplayMonitorProvider},
     DwallResult,
 };
 
-pub async fn get_monitors() -> DwallResult<HashMap<String, Monitor>> {
-    MonitorInfoProvider::new().get_monitors().await
+pub async fn get_monitors() -> DwallResult<HashMap<String, DisplayMonitor>> {
+    DisplayMonitorProvider::new().get_monitors().await
 }


### PR DESCRIPTION
- Rename Monitor to DisplayMonitor for better clarity
- Refactor cache implementation with improved naming and validation
- Encapsulate DisplayMonitor fields and provide accessor methods
- Rename query_monitor_info to fetch_system_monitors for consistency
- Simplify logging and improve monitor information handling