### PR TITLE
refactor(theme): rename and improve theme validation and daemon handling

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ use crate::i18n::get_translations;
 use crate::postion::request_location_permission;
 use crate::process_manager::kill_daemon;
 use crate::setup::setup_app;
-use crate::theme::{apply_theme, check_theme_exists, get_applied_theme_id};
+use crate::theme::{apply_theme, get_applied_theme_id, validate_theme};
 use crate::window::create_main_window;
 
 mod auto_start;
@@ -157,7 +157,7 @@ async fn main() -> DwallSettingsResult<()> {
             show_window,
             read_config_file,
             write_config_file,
-            check_theme_exists,
+            validate_theme,
             apply_theme,
             get_applied_theme_id,
             check_auto_start,

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -4,7 +4,7 @@ use tauri::Manager;
 
 use crate::{
     download::ThemeDownloader, error::DwallSettingsError, process_manager::find_daemon_process,
-    read_config_file, theme::spawn_apply_daemon, window::create_main_window, DAEMON_EXE_PATH,
+    read_config_file, theme::launch_daemon, window::create_main_window, DAEMON_EXE_PATH,
 };
 
 pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -48,7 +48,7 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         let _ = read_config_file()
             .await
             .and_then(|_| find_daemon_process())
-            .and_then(|pid| pid.map_or_else(|| spawn_apply_daemon().map(|_| ()), |_| Ok(())));
+            .and_then(|pid| pid.map_or_else(|| launch_daemon().map(|_| ()), |_| Ok(())));
     });
 
     info!("Application setup completed successfully");

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,12 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 
-export const checkThemeExists = async (
-  themesDirecotry: string,
-  themeId: string,
-) => invoke<void>("check_theme_exists", { themesDirecotry, themeId });
+export const validateTheme = async (themesDirecotry: string, themeId: string) =>
+  invoke<void>("validate_theme", { themesDirecotry, themeId });
 
 export const applyTheme = async (config: Config) =>
-  invoke("apply_theme", { config });
+  invoke<void>("apply_theme", { config });
 
 export const getAppliedThemeID = async (monitorId: string) =>
   invoke<string | null>("get_applied_theme_id", { monitorId });


### PR DESCRIPTION
- Rename check_theme_exists to validate_theme for clarity
- Rename spawn_apply_daemon to launch_daemon and improve error handling
- Add better logging and error recovery in apply_theme
- Improve daemon process monitoring with status checks