### PR TITLE
fix(ThemeContext): pass setMenuItemIndex to useLocationPermission

### DIFF
--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -63,6 +63,7 @@ export const ThemeProvider = (props: ParentProps) => {
   const { checkLocationPermission } = useLocationPermission(
     mutate,
     setShowSettings,
+    setMenuItemIndex,
   );
 
   // Use theme application Hook

--- a/src/hooks/useLocationPermission.tsx
+++ b/src/hooks/useLocationPermission.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from "~/contexts";
 export const useLocationPermission = (
   mutate: (fn: (prev: Config) => Config) => void,
   setShowSettings: (show: boolean) => void,
+  setMenuItemIndex: Setter<number | undefined>,
 ) => {
   const { translate } = useTranslations();
   // Check location permission
@@ -36,6 +37,7 @@ export const useLocationPermission = (
         ...prev!,
         coordinate_source: { type: "MANUAL" },
       }));
+      setMenuItemIndex();
       setShowSettings(true);
       return false;
     }


### PR DESCRIPTION
The setMenuItemIndex function was added as a parameter to useLocationPermission to properly reset the menu item index when location permission is denied. This ensures consistent UI state management.