### PR TITLE
feat(location): add option to open location settings when permission denied

### DIFF
--- a/daemon/src/position/geolocation_access.rs
+++ b/daemon/src/position/geolocation_access.rs
@@ -16,9 +16,10 @@ pub enum GeolocationAccessError {
 ///
 /// Returns Ok(()) if permission is granted, or an error if denied or unspecified
 pub async fn check_location_permission() -> DwallResult<()> {
-    let access_status = handle_windows_error("Requesting geolocation access permission", || {
-        Geolocator::RequestAccessAsync()
-    })
+    let access_status = handle_windows_error(
+        "Requesting geolocation access permission",
+        Geolocator::RequestAccessAsync,
+    )
     .await?
     .get()
     .map_err(|e| {

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -167,7 +167,9 @@ impl TranslationMap for EnglishUSTranslations {
         );
         translations.insert(
             MESSAGE_LOCATION_PERMISSION,
-            TranslationValue::Text("The location permission is not turned on. Please manually enable location or manually configure coordinates.\n\nDo you want to manually configure coordinates?\nClick \"Yes\" to manually configure coordinates, or click \"No\" to close the program."),
+            TranslationValue::Text(
+                "Location permission is not enabled. Please manually enable location or set coordinates manually.\n\nDo you want to set coordinates manually?\nClick 'Yes' to set coordinates manually, click 'No' to enable location.",
+            ),
         );
         translations.insert(
             MESSAGE_MANUAL_COORDINATES_SAVED,

--- a/src-tauri/src/i18n/locales/ja_jp.rs
+++ b/src-tauri/src/i18n/locales/ja_jp.rs
@@ -95,7 +95,9 @@ impl TranslationMap for JapaneseTranslations {
         );
         translations.insert(
             MESSAGE_LOCATION_PERMISSION,
-            TranslationValue::Text("位置情報の権限が有効になっていません。手動で位置情報を有効にするか、座標を手動で設定してください。\n\n座標を手動で設定しますか？\n「はい」をクリックして座標を手動設定するか、「いいえ」をクリックしてプログラムを終了します。"),
+            TranslationValue::Text(
+                "位置情報の権限が有効になっていません。位置情報を手動で有効にするか、座標を手動で設定してください。\n\n座標を手動で設定しますか？\n「はい」をクリックして座標を手動で設定する、「いいえ」をクリックして位置情報を有効にする。",
+            ),
         );
         translations.insert(
             MESSAGE_NUMBER_TOO_LARGE,

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -151,7 +151,9 @@ impl TranslationMap for ChineseSimplifiedTranslations {
         );
         translations.insert(
             MESSAGE_LOCATION_PERMISSION,
-            TranslationValue::Text("定位权限未打开，请手动开启定位或手动配置坐标。\n\n是否手动配置坐标？\n点击“是”手动配置坐标，点击“否”关闭程序"),
+            TranslationValue::Text(
+                "定位权限未打开，请手动开启定位或手动配置坐标。\n\n是否手动配置坐标？\n点击“是”手动配置坐标，点击“否”手动开启定位。",
+            ),
         );
         translations.insert(
             MESSAGE_MANUAL_COORDINATES_SAVED,

--- a/src-tauri/src/i18n/locales/zh_hk.rs
+++ b/src-tauri/src/i18n/locales/zh_hk.rs
@@ -84,7 +84,9 @@ impl TranslationMap for ChineseTraditionalHKTranslations {
         );
         translations.insert(
             MESSAGE_LOCATION_PERMISSION,
-            TranslationValue::Text("定位權限未開啟，請手動開啟定位或手動配置坐標。\n\n是否手動配置坐標？\n點擊「是」手動配置坐標，點擊「否」關閉程式"),
+            TranslationValue::Text(
+                "未啟用定位權限，請手動啟用定位或手動設定坐標。\n\n是否手動設定坐標？\n按「是」手動設定坐標，按「否」手動啟用定位。",
+            ),
         );
         translations.insert(
             MESSAGE_NUMBER_TOO_LARGE,

--- a/src-tauri/src/i18n/locales/zh_tw.rs
+++ b/src-tauri/src/i18n/locales/zh_tw.rs
@@ -84,7 +84,9 @@ impl TranslationMap for ChineseTraditionalTWTranslations {
         );
         translations.insert(
             MESSAGE_LOCATION_PERMISSION,
-            TranslationValue::Text("定位權限未開啟，請手動開啟定位或手動設定座標。\n\n是否手動設定座標？\n點擊「是」手動設定座標，點擊「否」結束程式"),
+            TranslationValue::Text(
+                "定位權限未開啟，請手動開啟定位或手動設定座標。\n\n是否手動設定座標？\n點選「是」手動設定座標，點選「否」手動開啟定位。",
+            ),
         );
         translations.insert(
             MESSAGE_NUMBER_TOO_LARGE,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -126,6 +126,11 @@ async fn get_monitors() -> DwallSettingsResult<HashMap<String, dwall::monitor::D
     Ok(monitors)
 }
 
+#[tauri::command]
+async fn open_privacy_location_settings() -> DwallSettingsResult<()> {
+    open::that("ms-settings:privacy-location").map_err(|e| e.into())
+}
+
 #[tokio::main]
 async fn main() -> DwallSettingsResult<()> {
     if cfg!(not(debug_assertions)) && cfg!(not(feature = "log-max-level-info")) {
@@ -175,6 +180,7 @@ async fn main() -> DwallSettingsResult<()> {
             clear_thumbnail_cache,
             get_translations,
             get_monitors,
+            open_privacy_location_settings
         ]);
 
     if cfg!(debug_assertions) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,7 @@
 export * from "./autostart";
 export * from "./config";
 export * from "./monitor";
+export * from "./shell";
 export * from "./system";
 export * from "./theme";
 export * from "./translation";

--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -1,0 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const openPrivacyLocationSettings = () =>
+  invoke<void>("open_privacy_location_settings");

--- a/src/hooks/useLocationPermission.tsx
+++ b/src/hooks/useLocationPermission.tsx
@@ -1,4 +1,7 @@
-import { requestLocationPermission } from "~/commands";
+import {
+  openPrivacyLocationSettings,
+  requestLocationPermission,
+} from "~/commands";
 
 import { ask } from "@tauri-apps/plugin-dialog";
 import { exit } from "@tauri-apps/plugin-process";
@@ -29,7 +32,8 @@ export const useLocationPermission = (
       );
 
       if (!shouldContinue) {
-        exit(0);
+        // exit(0);
+        await openPrivacyLocationSettings();
         return false;
       }
 


### PR DESCRIPTION
Add new command to open system privacy location settings when user denies location permission Update all translations to reflect new option to manually enable location Refactor location permission hook to use new command instead of exiting