### PR TITLE
ci: remove dependency on check-changed-paths in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   create-release:
-    needs: check-changed-paths
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
The create-release job no longer needs to wait for check-changed-paths to complete, simplifying the workflow execution