### PR TITLE
fix(DangerButton): prevent disabled button hover styles

### DIFF
--- a/src/components/DangerButton/DangerButton.css.ts
+++ b/src/components/DangerButton/DangerButton.css.ts
@@ -7,13 +7,13 @@ export const dangerButtonStyles = style({
   borderColor: themeContract.colorTransparentStroke,
 
   selectors: {
-    "&:hover": {
+    "&:not(:disabled):hover": {
       backgroundColor: themeContract.colorStatusDangerBackground3Hover,
       color: themeContract.colorNeutralForegroundOnBrand,
       borderColor: themeContract.colorTransparentStroke,
     },
 
-    "&:hover:active": {
+    "&:not(:disabled):hover:active": {
       background: themeContract.colorStatusDangerBackground3Pressed,
       color: themeContract.colorNeutralForegroundOnBrand,
       borderColor: themeContract.colorTransparentStroke,


### PR DESCRIPTION
The disabled state of DangerButton was incorrectly showing hover styles. Added :not(:disabled) selector to ensure hover styles only apply to enabled buttons.