### PR TITLE
ci: build dwall before running Rust checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rust-
 
+      # clippy need to build dwall first
+      - name: Build dwall
+        run: cargo build --release --package dwall
+
       - name: Run Rust checks
         run: |
           cargo fmt --check


### PR DESCRIPTION
Add build step for dwall package before running Rust checks to ensure clippy has necessary dependencies