### PR TITLE
ci(workflow): add auto-merge job for successful PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -106,7 +106,6 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.workflow == 'true'
 
-
     steps:
       - uses: actions/checkout@v4
 
@@ -144,3 +143,18 @@ jobs:
 
       - name: Cargo build
         run: cargo build
+
+  auto-merge:
+    name: Auto Merge PR
+    runs-on: ubuntu-latest
+    needs: [detect-changes, frontend-check, rust-check]
+    if: always() && !cancelled() && !failure()
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Auto merge PR
+        uses: pascalgn/automerge-action@v0.16.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_REMOVE_LABELS: "automerge"


### PR DESCRIPTION
Add auto-merge functionality to automatically merge PRs when all checks pass. Uses pascalgn/automerge-action with required permissions and token.