### PR TITLE
feat(settings): add github mirror template configuration component

### DIFF
--- a/src/components/Settings/GithubMirror/index.css.ts
+++ b/src/components/Settings/GithubMirror/index.css.ts
@@ -1,0 +1,13 @@
+import { style } from "@vanilla-extract/css";
+import { themeContract, vars } from "fluent-solid/lib/themes";
+
+export const code = style({
+  fontFamily: vars.fontFamilyMonospace,
+  borderColor: themeContract.colorNeutralStroke1,
+  borderStyle: "solid",
+  borderWidth: vars.strokeWidthThin,
+  borderRadius: vars.borderRadiusMedium,
+  backgroundColor: themeContract.colorNeutralBackground2,
+  padding: `${vars.spacingHorizontalXXS} ${vars.spacingVerticalXS}`,
+  display: "inline-block",
+});

--- a/src/components/Settings/GithubMirror/index.tsx
+++ b/src/components/Settings/GithubMirror/index.tsx
@@ -4,11 +4,13 @@ import { AiFillSave } from "solid-icons/ai";
 import { open } from "@tauri-apps/plugin-shell";
 
 import { LazyButton, LazyInput } from "~/lazy";
-import SettingsItem from "./Item";
+import SettingsItem from "../Item";
 
 import { writeConfigFile } from "~/commands";
 
 import { useToast, useConfig, useTranslations } from "~/contexts";
+
+import * as styles from "./index.css";
 
 const GithubMirror = () => {
   const { translate } = useTranslations();
@@ -22,11 +24,19 @@ const GithubMirror = () => {
   };
 
   const onConfirm = async () => {
-    await writeConfigFile({ ...config()!, github_mirror_template: value() });
+    const mirrorTemplate = value();
+    await writeConfigFile({
+      ...config()!,
+      github_mirror_template: mirrorTemplate,
+    });
     refetchConfig();
     toast.success(
       translate("message-github-mirror-template-updated", {
-        newTemplate: value() ?? "",
+        newTemplate: mirrorTemplate ? (
+          <code class={styles.code}>{mirrorTemplate}</code>
+        ) : (
+          ""
+        ),
       }),
     );
   };


### PR DESCRIPTION
Introduce a new component for configuring github mirror template in settings. Includes input field with save functionality and styling using vanilla-extract CSS.