### PR TITLE
ci(workflows): add write permission and fix release condition

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,6 +125,8 @@ jobs:
 
   delete-existing-nightly:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: check-nightly-conditions
     if: needs.check-nightly-conditions.outputs.should_build == 'true' && needs.check-nightly-conditions.outputs.has_nightly == 'true'
     steps:
@@ -143,7 +145,8 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     needs: [check-nightly-conditions, delete-existing-nightly]
-    if: always() && needs.check-nightly-conditions.outputs.should_build == 'true'
+    if: always() && needs.check-nightly-conditions.outputs.should_build == 'true' && needs.delete-existing-nightly.result != 'failure'
+
     outputs:
       release_id: ${{ steps.create-release.outputs.result }}
       build_date: ${{ steps.date.outputs.date }}


### PR DESCRIPTION
Add write permission for delete-existing-nightly job and ensure release job only runs if delete job succeeds